### PR TITLE
Always resolve version

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,379 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating,W0106,W0702
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='  '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=2
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/src/ef-version.py
+++ b/src/ef-version.py
@@ -402,7 +402,11 @@ def cmd_rollback(context):
 
 def _getlatest_ami_id(context):
   """
-  blah blah blah
+  Get the most recent AMI ID for a service
+  Args:
+    context: a populated EFVersionContext object
+  Returns:
+    ImageId or None if no images exist or on error
   """
   try:
     response = context.aws_client("ec2").describe_images(

--- a/src/ef-version.py
+++ b/src/ef-version.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 import argparse
 from inspect import isfunction
 import json
+from operator import itemgetter
 from os import getenv
 import sys
 
@@ -246,8 +247,6 @@ def handle_args_and_set_context(args):
 
   return context
 
-
-
 def print_if_verbose(message):
   if VERBOSE:
     print(message, file=sys.stderr)
@@ -266,7 +265,7 @@ def precheck_ami_id(context):
   # get the current AMI
   key = "{}/{}".format(context.service_name, context.env)
   print_if_verbose("precheck_ami_id with key: {}".format(key))
-  current_ami=context.versionresolver.lookup("ami-id/norecurse,{}".format(key))
+  current_ami=context.versionresolver.lookup("ami-id,{}".format(key))
   print_if_verbose("ami found: {}".format(current_ami))
 
   # If bootstrapping (this will be the first entry in the version history)
@@ -281,7 +280,7 @@ def precheck_ami_id(context):
   instances_running_ami = context.aws_client("ec2").describe_instances(
     Filters=[{
       'Name': 'image-id',
-      'Values': [ current_ami  ]
+      'Values': [ current_ami ]
     }]
   )["Reservations"]
   if instances_running_ami:
@@ -401,6 +400,23 @@ def cmd_rollback(context):
   context.stable = True
   cmd_set(context)
 
+def _getlatest_ami_id(context):
+  """
+  blah blah blah
+  """
+  try:
+    response = context.aws_client("ec2").describe_images(
+      Filters=[
+        {"Name": "is-public", "Values": ["false"]},
+        {"Name": "name", "Values": [context.service_name + EFConfig.AMI_SUFFIX + "*"]}
+      ])
+  except:
+    return None
+  if len(response["Images"]) > 0:
+    return sorted(response["Images"], key=itemgetter('CreationDate'), reverse=True)[0]["ImageId"]
+  else:
+    return None
+
 def cmd_set(context):
   """
   Set the new "current" value for a key.
@@ -413,8 +429,8 @@ def cmd_set(context):
   if not context.service_registry.service_record(context.service_name):
     fail("service: {} not found in service registry: {}".format(context.service_name, context.service_registry.filespec))
   # Key must be whitelisted
-  if context.key not in context.service_registry.version_keys():
-    fail("key: {} is unknown; see whitelist in version_keys in service registry".format(context.key))
+  if context.key not in EFConfig.VERSION_KEYS:
+    fail("key: {} is unknown; see whitelist in VERSION_KEYS in ef_config".format(context.key))
 
   # If key value is a special symbol, see if this env allows it
   if context.value in EFConfig.SPECIAL_VERSIONS and not context.env_short in EFConfig.SPECIAL_VERSION_ENVS:
@@ -422,9 +438,21 @@ def cmd_set(context):
   # If key value is a special symbol, the record cannot be marked "stable"
   if context.value in EFConfig.SPECIAL_VERSIONS and context.stable:
     fail("special versions such as: {} cannot be marked 'stable'".format(context.value))
-  # If special symbol is "=latest", does this key allow it?
-  if context.value == "=latest" and not context.service_registry.allows_latest(context.key):
-    fail("=latest cannot be used with key: {}".format(context.key))
+
+  # Resolve any references
+  if context.value == "=prod":
+    context.value = context.versionresolver.lookup("{},{}/{}".format(context.key, "prod", context.service_name))
+  elif context.value == "=staging":
+    context.value = context.versionresolver.lookup("{},{}/{}".format(context.key, "staging", context.service_name))
+  elif context.value == "=latest":
+    if not EFConfig.VERSION_KEYS[context.key]["allow_latest"]:
+      fail("=latest cannot be used with key: {}".format(context.key))
+    func_name = "_getlatest_" + context.key.replace("-", "_")
+    if globals().has_key(func_name) and isfunction(globals()[func_name]):
+      context.value = globals()[func_name](context)
+    else:
+      raise RuntimeError("{} version for {}/{} is '=latest' but can't look up because method not found: {}".format(
+        context.key, context.env, context.service_name, func_name))
 
   # precheck to confirm coherent world state before attempting set - whatever that means for the current key type
   try:

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -49,6 +49,8 @@ class EFConfig(EFSiteConfig):
   ACCOUNT_SCOPED_ENVS = ["global", "mgmt"]
 
   ## Version system
+  # suffix used for naming deployable service AMIs
+  AMI_SUFFIX = "-release"
   # content-encoding for S3 version registry
   S3_VERSION_CONTENT_ENCODING = "utf-8"
   # Metdata key on a version object to indicate who modified it
@@ -58,6 +60,10 @@ class EFConfig(EFSiteConfig):
   # Metadata version status values
   S3_VERSION_STATUS_STABLE = "stable"
   S3_VERSION_STATUS_UNDEFINED = "undefined"
-  # What values other than a literal version are allowed for each environment?
-  # Some envs' version entries can be set to these special values, meaning 'use the value found there'
+  VERSION_KEYS = {
+    "ami-id": {
+      "allow_latest": "true"
+    }
+  }
+  # Some envs' version entries can be set via these special values, meaning 'use the value found there'
   SPECIAL_VERSIONS = ["=latest", "=prod", "=staging"]

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -62,7 +62,7 @@ class EFConfig(EFSiteConfig):
   S3_VERSION_STATUS_UNDEFINED = "undefined"
   VERSION_KEYS = {
     "ami-id": {
-      "allow_latest": "true"
+      "allow_latest": True
     }
   }
   # Some envs' version entries can be set via these special values, meaning 'use the value found there'


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Simplify version resolver to strictly get versions from the version bucket. 

Reference resolution moves to ef-version. This means that references are no longer written to the version bucket and instead are immediately resolved to the respective ami-id which is then written to the bucket. 

## Changelog
* add pylintrc
* Version lookups no longer support a recurse switch
* VERSION_KEYS moves into ef_config


