### PR TITLE
Dynamic env resolution

### DIFF
--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -39,7 +39,6 @@ class EFSiteConfig:
   #   "proto": "mycompanynonprod",
   #   "staging": "mycompanynonprod"
   ENV_ACCOUNT_MAP = {
-    "alpha": "",
     "internal": "",
     "prod": "",
     "proto": "",
@@ -49,10 +48,9 @@ class EFSiteConfig:
   # Map environment::number for environments that support multiple ephemeral replicas
   # Resolves as proto<0..N> up to number - 1 (proto0, proto1, proto2, proto3 for N = 4)
   # prod and account scoped envs are not allowed
-  #   "alpha": Int,
-  #   "proto": Int,
+  #   "myephemeralenv": Int,
+  #   "proto": Int
   EPHEMERAL_ENVS = {
-    "alpha": 4,
     "proto": 4
   }
 

--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -47,7 +47,7 @@ class EFSiteConfig:
 
   # Map environment::number for environments that support multiple ephemeral replicas
   # Resolves as proto<0..N> up to number - 1 (proto0, proto1, proto2, proto3 for N = 4)
-  # prod and account scoped envs are not allowed
+  # prod and account scoped envs are not allowed to be ephemeral
   #   "myephemeralenv": Int,
   #   "proto": Int
   EPHEMERAL_ENVS = {

--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -34,38 +34,26 @@ class EFSiteConfig:
   EF_REPO_BRANCH = ""
 
   # Map environment::account alias (aliases must have matching profiles in .aws/credentials)
-  #   Include:
-  #     "account" - account alias
-  #     "number" - Number of named environments, numbered 0..N-1 (4 or fewer recommended)
-  #   Example: PROTO_ENVS = 4
-  #   Example, assuming there are 3 AWS accounts altogether
-  #   "internal": {
-  #     "account": "mycompanyint"
-  #   },
-  #   "prod": {
-  #     "account": "mycompany"
-  #   },
-  #   "proto": {
-  #     "account": "mycompanynonprod",
-  #     "number": 4
-  #   }.
-  #   "staging": {
-  #     "account": "mycompanynonprod"
-  #   }
-
+  #   "internal": "mycompanyint",
+  #   "prod": "mycompany",
+  #   "proto": "mycompanynonprod",
+  #   "staging": "mycompanynonprod"
   ENV_ACCOUNT_MAP = {
-    "internal": {
-      "account": ""
-    },
-    "prod": {
-      "account": ""
-    },
-    "proto": {
-      "account": ""
-    },
-    "staging": {
-      "account": ""
-    }
+    "alpha": "",
+    "internal": "",
+    "prod": "",
+    "proto": "",
+    "staging": "",
+  }
+
+  # Map environment::number for environments that support multiple ephemeral replicas
+  # Resolves as proto<0..N> up to number - 1 (proto0, proto1, proto2, proto3 for N = 4)
+  # prod and account scoped envs are not allowed
+  #   "alpha": Int,
+  #   "proto": Int,
+  EPHEMERAL_ENVS = {
+    "alpha": 4,
+    "proto": 4
   }
 
   # Bucket where late-bound service configs are found. See doc/name-patterns.md for S3 bucket naming conventions

--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -43,7 +43,7 @@ class EFSiteConfig:
     "internal": "",
     "prod": "",
     "proto": "",
-    "staging": "",
+    "staging": ""
   }
 
   # Map environment::number for environments that support multiple ephemeral replicas

--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -34,21 +34,39 @@ class EFSiteConfig:
   EF_REPO_BRANCH = ""
 
   # Map environment::account alias (aliases must have matching profiles in .aws/credentials)
-  #   Example, assuming there are 3 AWS account altogether
-  #   "internal": "mycompanyint",
-  #   "prod": "mycompany",
-  #   "proto": "mycompanynonprod",
-  #   "staging": "mycompanynonprod"
-  ENV_ACCOUNT_MAP = {
-    "internal": "",
-    "prod": "",
-    "proto": "",
-    "staging": ""
-  }
-
-  # Number of prototype environments, numbered 0..N-1 (4 or fewer recommended)
+  #   Include:
+  #     "account" - account alias
+  #     "number" - Number of named environments, numbered 0..N-1 (4 or fewer recommended)
   #   Example: PROTO_ENVS = 4
-  PROTO_ENVS = 4
+  #   Example, assuming there are 3 AWS accounts altogether
+  #   "internal": {
+  #     "account": "mycompanyint"
+  #   },
+  #   "prod": {
+  #     "account": "mycompany"
+  #   },
+  #   "proto": {
+  #     "account": "mycompanynonprod",
+  #     "number": 4
+  #   }.
+  #   "staging": {
+  #     "account": "mycompanynonprod"
+  #   }
+
+  ENV_ACCOUNT_MAP = {
+    "internal": {
+      "account": ""
+    },
+    "prod": {
+      "account": ""
+    },
+    "proto": {
+      "account": ""
+    },
+    "staging": {
+      "account": ""
+    }
+  }
 
   # Bucket where late-bound service configs are found. See doc/name-patterns.md for S3 bucket naming conventions
   #   Bucket name should be in this form: <S3PREFIX>-global-configs

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -41,7 +41,7 @@ class EFConfig(EFSiteConfig):
   ENV_LIST = []
   VALID_ENV_REGEX = ""
   for env in EFSiteConfig.ENV_ACCOUNT_MAP.keys():
-    if "number" in EFSiteConfig.ENV_ACCOUNT_MAP[env]:
+    if "number" in EFSiteConfig.ENV_ACCOUNT_MAP[env] and EFSiteConfig.ENV_ACCOUNT_MAP[env]["number"] > 1:
       ENV_LIST.extend((lambda env=env: [env + str(x) for x in range(EFSiteConfig.ENV_ACCOUNT_MAP[env]["number"])])())
       VALID_ENV_REGEX += "{}[0-{}]|".format(env, EFSiteConfig.ENV_ACCOUNT_MAP[env]["number"] - 1)
     else:

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -35,7 +35,7 @@ class EFConfig(EFSiteConfig):
   EFSiteConfig.SERVICE_GROUPS.add("fixtures")
 
   # Convenient list of all mapped accounts
-  ACCOUNT_ALIAS_LIST = set(x for x in EFSiteConfig.ENV_ACCOUNT_MAP.values())
+  ACCOUNT_ALIAS_LIST = set(EFSiteConfig.ENV_ACCOUNT_MAP.values())
 
   # These environments are for account-wide resources; they have a ".<ACCOUNT_ALIAS>" suffix
   ACCOUNT_SCOPED_ENVS = ["global", "mgmt"]

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -33,17 +33,25 @@ class EFConfig(EFSiteConfig):
   POLICY_TEMPLATE_PATH_SUFFIX = "/policy_templates/"
   # the service group 'fixtures' always exists
   EFSiteConfig.SERVICE_GROUPS.add("fixtures")
-  VALID_ENV_REGEX = "prod|staging|proto[0-{}]|global|mgmt|internal".format(EFSiteConfig.PROTO_ENVS - 1)
 
   # Convenient list of all mapped accounts
-  ACCOUNT_ALIAS_LIST = set(EFSiteConfig.ENV_ACCOUNT_MAP.values())
+  ACCOUNT_ALIAS_LIST = set(x["account"] for x in EFSiteConfig.ENV_ACCOUNT_MAP.values())
 
   # Convenient list of all possible valid environments
-  ENV_LIST = ["prod", "staging", "internal"]
+  ENV_LIST = []
+  VALID_ENV_REGEX = ""
+  for env in EFSiteConfig.ENV_ACCOUNT_MAP.keys():
+    if "number" in EFSiteConfig.ENV_ACCOUNT_MAP[env]:
+      ENV_LIST.extend((lambda env=env: [env + str(x) for x in range(EFSiteConfig.ENV_ACCOUNT_MAP[env]["number"])])())
+      VALID_ENV_REGEX += "{}[0-{}]|".format(env, EFSiteConfig.ENV_ACCOUNT_MAP[env]["number"] - 1)
+    else:
+      ENV_LIST.append(env)
+      VALID_ENV_REGEX += "{}|".format(env)
+
   ENV_LIST.extend("global." + x for x in ACCOUNT_ALIAS_LIST)
   ENV_LIST.extend("mgmt." + x for x in ACCOUNT_ALIAS_LIST)
-  ENV_LIST.extend("proto" + str(x) for x in range(EFSiteConfig.PROTO_ENVS))
   ENV_LIST = sorted(ENV_LIST)
+  VALID_ENV_REGEX += "global|mgmt"
 
   # These environments are for account-wide resources; they have a ".<ACCOUNT_ALIAS>" suffix
   ACCOUNT_SCOPED_ENVS = ["global", "mgmt"]

--- a/src/ef_config_resolver.py
+++ b/src/ef_config_resolver.py
@@ -31,7 +31,7 @@ class EFConfigResolver(object):
     """
     Return account alias of the account that hosts the env named in lookup, None otherwise
     Params:
-      lookup: ENV_SHORT name of an env, one of: 'prod', 'staging', 'proto', or 'internal'
+      lookup: ENV_SHORT name of an env, such as: 'prod' or 'proto'
     """
 
     if lookup in EFConfig.ENV_ACCOUNT_MAP:

--- a/src/ef_config_resolver.py
+++ b/src/ef_config_resolver.py
@@ -34,8 +34,8 @@ class EFConfigResolver(object):
       lookup: ENV_SHORT name of an env, one of: 'prod', 'staging', 'proto', or 'internal'
     """
 
-    if EFConfig.ENV_ACCOUNT_MAP.has_key(lookup):
-      return EFConfig.ENV_ACCOUNT_MAP[lookup]
+    if lookup in EFConfig.ENV_ACCOUNT_MAP:
+      return EFConfig.ENV_ACCOUNT_MAP[lookup]["account"]
     else:
       return None
 

--- a/src/ef_config_resolver.py
+++ b/src/ef_config_resolver.py
@@ -35,7 +35,7 @@ class EFConfigResolver(object):
     """
 
     if lookup in EFConfig.ENV_ACCOUNT_MAP:
-      return EFConfig.ENV_ACCOUNT_MAP[lookup]["account"]
+      return EFConfig.ENV_ACCOUNT_MAP[lookup]
     else:
       return None
 

--- a/src/ef_context.py
+++ b/src/ef_context.py
@@ -28,10 +28,9 @@ class EFContext(object):
   def __init__(self):
     # service environment
     self._account_alias = None
-    self._env = None # prod, staging, proto<n>, global, mgmt, internal -- the name used in AWS
-    self._env_short = None # prod, staging, proto, global, mgmt, internal -- the generic name for matching when templating
-    # _env_full deals with naming differences for "proto<n>", "global.<alias>", "mgmt.<alias>" in the service registry
-    self._env_full = None # prod, staging, proto, global.<account_alias>, mgmt.<account_alias>, internal -- name found in SR
+    self._env = None # the name used in AWS -- e.g. prod, proto<n>, mgmt
+    self._env_short = None # the generic name -- e.g. prod, proto, mgmt
+    self._env_full = None # name found in SR -- e.g. prod, proto, mgmt.<account_alias>
     self._service = None
     # Service registry object
     self._service_registry = None
@@ -57,7 +56,8 @@ class EFContext(object):
     """
     Sets context.env, context.env_short, and context.account_alias if env is valid
     For envs of the form "global.<account>" and "mgmt.<account_alias>",
-    env is captured as "global" or "mgmt" and account_alias is parsed out of the full env rather than looked up
+    env is captured as "global" or "mgmt" and account_alias is parsed
+    out of the full env rather than looked up
     Args:
       value: the fully-qualified env value
     Raises:
@@ -78,12 +78,12 @@ class EFContext(object):
 
   @property
   def env_short(self):
-    """Short (generic) name of the environment, e.g. 'prod' or 'proto' or 'global'"""
+    """Short (generic) name of the environment, e.g. 'prod' or 'proto' or 'mgmt'"""
     return self._env_short
 
   @property
   def env_full(self):
-    """Name of the environment as expected in the service registry, e.g. 'prod' or 'proto' or 'global.ellationeng'"""
+    """Name of the environment as expected in the service registry, e.g. 'prod' or 'proto' or 'mgmt.ellationeng'"""
     return self._env_full
 
   @property

--- a/src/ef_service_registry.py
+++ b/src/ef_service_registry.py
@@ -130,8 +130,8 @@ class EFServiceRegistry(object):
     service_record_envs = service_record["environments"]
     result = []
     for service_env in service_record_envs:
-      if service_env in EFConfig.ENV_ACCOUNT_MAP and "number" in EFConfig.ENV_ACCOUNT_MAP[service_env]:
-        result.extend((lambda env=service_env: [env + str(x) for x in range(EFConfig.ENV_ACCOUNT_MAP[env]['number'])])())
+      if service_env not in EFConfig.PROTECTED_ENVS and service_env in EFConfig.EPHEMERAL_ENVS:
+        result.extend((lambda env=service_env: [env + str(x) for x in range(EFConfig.EPHEMERAL_ENVS[env])])())
       else:
         result.append(service_env)
     return result

--- a/src/ef_service_registry.py
+++ b/src/ef_service_registry.py
@@ -130,8 +130,8 @@ class EFServiceRegistry(object):
     service_record_envs = service_record["environments"]
     result = []
     for service_env in service_record_envs:
-      if "proto" == service_env:
-        result.extend(map(lambda x: "proto" + str(x), range(EFConfig.PROTO_ENVS)))
+      if service_env in EFConfig.ENV_ACCOUNT_MAP and "number" in EFConfig.ENV_ACCOUNT_MAP[service_env]:
+        result.extend((lambda env=service_env: [env + str(x) for x in range(EFConfig.ENV_ACCOUNT_MAP[env]['number'])])())
       else:
         result.append(service_env)
     return result

--- a/src/ef_template_resolver.py
+++ b/src/ef_template_resolver.py
@@ -98,13 +98,13 @@ class EFTemplateResolver(object):
           "myvarA2": "myvalueA2",
           ...
   Valid <env> values are:
-    "default", "prod", "staging", "proto", "proto<0>".."proto<N>", "internal", "localvm"
+    "default", "prod", "staging", "proto", "proto<0>".."proto<N>", "localvm", etc.
   <env> sections are evaluated hierarchically, in this order:
     1) "default" - optional; if present is always applied first
-    2) the general environment: "prod", "staging", "proto" ("any proto<0>..<N>"), or "internal"
-    3) "proto<N>" - the specific proto environment, if any
-  The "proto" env evaluation happens as it does to allow "proto" to set generic values for allow
-  prototype environments. Then proto<N> values can be applied to a set of proto envs if necessary
+    2) the general environment: "prod", "staging", "proto" ("any proto<0>..<N>"), etc.
+    3) "proto<N>" - the specific ephemeral environment, if any
+  The ephemeral env evaluation happens to allow for example, "proto" to set generic values for all
+  proto<N> environments. Then proto<N> values can be applied to specific proto envs if necessary
   to customize for the specific environment.
 
   """
@@ -168,9 +168,9 @@ class EFTemplateResolver(object):
       {{ACCOUNT}}       - AWS account number
                           CloudFormation can use this or the AWS::AccountID pseudo param
       {{ACCOUNT_ALIAS}} - AWS account alias
-      {{ENV}}           - environment: global, mgmt, prod, staging, proto<N>, internal
-      {{ENV_SHORT}}     - env with <N> trimmed: global, prod, staging, proto, internal
-      {{ENV_FULL}}      - env fully qualified: prod, staging, proto<N>, internal, mgmt.<account_alias>, global.<account_alias>
+      {{ENV}}           - environment: mgmt, prod, staging, proto<N>, etc.
+      {{ENV_SHORT}}     - env with <N> or account trimmed: mgmt, prod, staging, proto, etc.
+      {{ENV_FULL}}      - env fully qualified: prod, staging, proto<N>, mgmt.<account_alias>, etc.
       {{FUNCTION_NAME}} - only for lambdas
       {{INSTANCE_ID}}   - only for ec2
       {{REGION}}        - the region currently being worked in

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -202,7 +202,7 @@ def get_account_alias(env):
   """
   Given an env, return <account_alias> if env is valid
   Args:
-    env: an environment, one of "prod", "staging", "proto<N>", "internal", "global.<account_alias>", or "mgmt.<account_alias>"
+    env: an environment, such as "prod", "staging", "proto<N>", "mgmt.<account_alias>"
   Returns:
     the alias of the AWS account that holds the env
   Raises:
@@ -224,9 +224,9 @@ def get_env_short(env):
   """
   Given an env, return <env_short> if env is valid
   Args:
-    env: an environment, one of "prod", "staging", "proto<N>", "internal", "global.<account_alias>", or "mgmt.<account_alias>"
+    env: an environment, such as "prod", "staging", "proto<N>", "mgmt.<account_alias>"
   Returns:
-    the shortname of the env, one of "prod", "staging", "proto", "internal", "global", or "mgmt"
+    the shortname of the env, such as "prod", "staging", "proto", "mgmt"
   Raises:
     ValueError if env is misformatted or doesn't name a known environment
   """

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -217,8 +217,8 @@ def get_account_alias(env):
   else:
     env_short = env.strip(".0123456789")
     if env_short not in EFConfig.ENV_ACCOUNT_MAP:
-      raise ValueError("generic env: {} has no entry in ENV_ACCOUNT_MAP of ef_config.py".format(env_short))
-    return EFConfig.ENV_ACCOUNT_MAP[env_short]["account"]
+      raise ValueError("generic env: {} has no entry in ENV_ACCOUNT_MAP of ef_site_config.py".format(env_short))
+    return EFConfig.ENV_ACCOUNT_MAP[env_short]
 
 def get_env_short(env):
   """

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -216,9 +216,9 @@ def get_account_alias(env):
   # Ordinary env, possibly a proto env ending with a digit that is stripped to look up the alias
   else:
     env_short = env.strip(".0123456789")
-    if not EFConfig.ENV_ACCOUNT_MAP.has_key(env_short):
+    if env_short not in EFConfig.ENV_ACCOUNT_MAP:
       raise ValueError("generic env: {} has no entry in ENV_ACCOUNT_MAP of ef_config.py".format(env_short))
-    return EFConfig.ENV_ACCOUNT_MAP[env_short]
+    return EFConfig.ENV_ACCOUNT_MAP[env_short]["account"]
 
 def get_env_short(env):
   """


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Dynamically resolve environment list and quantity of env replicas based on ENV_ACCOUNT_MAP in ef_site_config. This offloads values from ef_config that are more appropriately set in ef_site_config. 

This is effectively one approach to solving the issue and is up for discussion.

## Changelog
* dynamically resolve ENV_LIST and VALID_ENV_REGEX
* update example
* introduce protected and ephemeral envs

## Test
```
toverton:~/Documents/Ellation/dev/ef-open dynamic-env-resolution $ python ./src/test_ef_aws_resolver.py
................................................
----------------------------------------------------------------------
Ran 48 tests in 12.306s

OK
toverton:~/Documents/Ellation/dev/ef-open dynamic-env-resolution $ python ./src/test_ef_config_resolver.py
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
toverton:~/Documents/Ellation/dev/ef-open dynamic-env-resolution $ python ./src/test_ef_service_registry.py
.....
----------------------------------------------------------------------
Ran 5 tests in 0.045s

OK
toverton:~/Documents/Ellation/dev/ef-open dynamic-env-resolution $ python ./src/test_ef_template_resolver.py
......
----------------------------------------------------------------------
Ran 6 tests in 9.673s

OK
toverton:~/Documents/Ellation/dev/ef-open dynamic-env-resolution $ python ./src/test_ef_utils.py
....
----------------------------------------------------------------------
Ran 4 tests in 0.000s

OK
toverton:~/Documents/Ellation/dev/ef-open dynamic-env-resolution $ python ./src/test_ef_version_resolver.py
.
----------------------------------------------------------------------
Ran 1 test in 0.492s

OK
```
