### PR TITLE
build script must export repo + update & correct install docs

### DIFF
--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -9,9 +9,10 @@ To build the ef-open tools, you will need to...
 
 ### Preliminaries
 
-Below are tl;dr instructions that have worked for the ef_open maintainers. For full details and the latest instructions, see:
+Below are tl;dr instructions that have worked for the ef_open maintainers.<br>
+For full details and the latest instructions, see:
 - [Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org
-- [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md)
+- [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md) at github.com/pantsbuild
 - [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pantsbuild.github.io
 
 #### Assumptions in the examples and instructions below
@@ -30,7 +31,7 @@ Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;
   <code>ef-open/getting-started/BUILD.ef_site_config</code> <--- ready-to-go build file to copy to <code>&lt;REPO&gt;/BUILD.ef_site_config</code>
 
 ### INSTALL: install pants
-*Do this on any system that will build the tools, such as tool maintainers' laptops, and Jenkins*
+*Do this on any system that will build the ef-open tools, such as tool maintainers' laptops, and Jenkins*
 
 <code>cd</code> to the directory above all the repos, which in these examples is <code>~/workspace</code>, then
 install pants there following the instructions below... or use chef or other configuration tool to install it on

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -4,33 +4,27 @@ To build the ef-open tools, you will need to...
 | What | Where | When |
 | --- | --- | --- |
 | INSTALL:<br>install pants | on every system that will use pants to build (your laptop, Jenkins, ...) | once per system |
-| CUSTOMIZE:<br>configure "ef_site_config.py" and copy in the provided BUILD.siteconfig | your infrastructure repo(s) | once per repo initially (and any time you need to change a config value in ef_site_config.py) |
-| BUILD:<br>export an environment variable to tell pants where ef_site_config.py is, then run pants<br>_or_<br>use the example script, <code>tools/build-ef-open</code> that checks setup and runs pants | any pants-capable system | every time you build ef-open (whenever there's an update to /src or your revise your ef_site_config.py) |
+| CUSTOMIZE:<br>configure "ef_site_config.py"<br>copy in the provided BUILD.siteconfig | your infrastructure repo(s) | once per repo initially (and later to change a value in ef_site_config.py) |
+| BUILD:<br>export an environment variable to tell pants where ef_site_config.py is, then run pants<br>_or_<br>use the example script, <code>tools/build-ef-open</code> that checks setup and runs pants | any pants-capable system | every time you build ef-open<br>(whenever there's an update to /src or your revise your ef_site_config.py) |
 
 ### Preliminaries
-As the time this was written, the pants installation instructions at [http://www.pantsbuild.org/install.html](http://www.pantsbuild.org/install.html)
-were not in sync with the newer instructions in the pants repo at [https://github.com/pantsbuild/pants/blob/master/README.md](https://github.com/pantsbuild/pants/blob/master/README.md) and will install an old version of pants.
 
-Accordingly, these instructions use pip to install pants from PyPI to <code>/usr/local/bin</code> per the PyPI reference in [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md).
-
-In the instructions and examples below, <code>~/workspace</code> is the common directory above all repos.<br>
-Pants has a .ini file there, and will make some visible and invisible (dot-file) directories inside it.
-
-For full details and the latest instructions, see
-- [Installing Packages](http://www.pantsbuild.org/install.html) at python.org (for pip, if you don't have it)
+Below are tl;dr instructions that have worked for the ef_open maintainers. For full details and the latest instructions, see:
+- [Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org
 - [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md)
-- [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io
+- [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pantsbuild.github.io
 
-#### Assumptions in all examples and instructions below
+#### Assumptions in the examples and instructions below
 - The common directory above all repos is <code>~/workspace</code>
+  - Pants has a <code>pants.ini</code> file there, and will make some visible and invisible (dot-file) directories inside it.
 - The ef-open repo is called <code>ef-open</code> at <code>~/workspace/ef-open</code>
 - Your company or project's Cloudformation infrastructure repo is already set up (possibly empty, but ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.<br>
 Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;</code>.
 - Overall structure of stuff discussed here is:<br>
-<code>  ~/workspace</code> <--- Common top-level directory above all repos (Installed pants here and cd to here to build)<br>
+<code>  ~/workspace</code> <--- Common top-level directory above all repos (Install pants here; cd to here to build)<br>
 <code>  ~/workspace/ef-open</code> <--- ef-open repo, sync'd with ef-open at github<br>
-<code>  ~/workspace/&lt;REPO&gt;</code> <--- your infrastructure repo containing the localized <code>/ef_site_config.py</code><br>
-<code>  &lt;REPO&gt;/ef_site_config.py</code> <--- your project/company-specific ef-open configuration file<br>
+<code>  ~/workspace/&lt;REPO&gt;</code> <--- your infrastructure repo where CloudFormation templatesa and other ef-open files go<br>
+<code>  ~/workspace/&lt;REPO&gt;/ef_site_config.py</code> <--- your project/company-specific ef-open configuration file<br>
 - To get you started, ef-open provides:<br>
   <code>ef-open/getting-started/ef_site_config.py</code> <--- starter site config file to copy to <code>&lt;REPO&gt;/ef_site_config.py</code> and then customize<br>
   <code>ef-open/getting-started/BUILD.ef_site_config</code> <--- ready-to-go build file to copy to <code>&lt;REPO&gt;/BUILD.ef_site_config</code>
@@ -39,50 +33,38 @@ Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;
 *Do this on any system that will build the tools, such as tool maintainers' laptops, and Jenkins*
 
 <code>cd</code> to the directory above all the repos, which in these examples is <code>~/workspace</code>, then
-use pip to install pants... or use chef or other configuration tool to install it on a build server.
+install pants there following the instructions below... or use chef or other configuration tool to install it on
+a build server.
 
 The maintainers of ef-open currently build ef-open with version 1.2.1 of pants. The BUILD files for ef-open are not complex,
-and will probably work with other versions of pants.
+and will probably work with other versions of pants. You can also install pants elsewhere (such as to /usr/local/bin). In
+this document, it's installed into <code>~/workspace</code>.
+
 ```bash
-# to install version 1.2.1 specifically, using pip:
 $ cd ~/workspace
-$ sudo pip install pantsbuild.pants==1.2.1
-$ touch pants  # pants requires a file with this name in the cwd, even if the binary is really somewhere else
-
-# or to install the latest version, using pip:
-$ cd ~/workspace
-$ sudo pip install pantsbuild.pants
-$ touch pants  # pants requires a file with this name in the cwd, even if the binary is really somewhere else
+$ curl -L -O https://pantsbuild.github.io/setup/pants && chmod +x pants && touch pants.ini
 ```
 
-Check that pants runs, and get its version number
-```
-$ which pants
-/usr/local/bin/pants
+Run pants the first time, and it will self-update to the latest version.<br>
+If this returns a message like "No goals specified." then your copy of pants is current.
+```bash
+$ ./pants
 ```
 
-It's on the search path so you shouldn't need to call it out explicitly if this is the only copy you have
+Get the pants version number
 ```
-$ pants -V
+$ ./pants -V
 1.2.1
 ```
-If pants won't run on your OS/X installation, take a look at the discussion here:
-[https://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade](https://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade)
 
-For us, this step from the conversation above solved a versioning issue (old version found first) caused by a python path problem in OS/X:<br>
-<code>$ sudo cat > /Library/Python/2.7/site-packages/fix_mac_path.pth</code><br>
-<code>import sys; std_paths=[p for p in sys.path if p.startswith('/System/') and not '/Extras/' in p]; sys.path=[p for p in sys.path if not p.startswith('/System/')]+std_paths</code><br>
-<code>^D</code><br>
-
-Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using the pants version found in the previous step
+Edit <code>~/workspace/pants.ini</code> to add these lines to pin the pants version, using the version number found in the previous step.<br>
+Note: If this file is created _before_ pants is installed, pants will self-update if necessary to the desired version and stay there.
 ```
 [GLOBAL]
 pants_version: 1.2.1
 ```
 
-Pants is now installed. If you installed with pip, it's on probably your path, so in the examples below we'll
-call it without a path.<br>
-On a build server, you may need or prefer to always specify the full path to the pants binary.
+Pants is now installed.
 
 ### CUSTOMIZE: configure ef-open for your AWS environment<BR>
 *Do this once for each infrastructure repo*
@@ -91,7 +73,7 @@ Copy the ef_site_config.py template from ef-open/getting-started
 ```bash
 $ cp ~/workspace/ef-open/getting-started/ef_site_config.py ~/workspace/<REPO>/ef_site_config.py
 ```
-Define custom values for your tooling
+Define custom values for your AWS account and configuration
 - edit <code>~/workspace/&lt;REPO&gt;/ef_site_config.py</code>
 - localize all values for the company/project following the examples in comments in the file
 - save the updated <code>~/workspace/&lt;REPO&gt;/ef_site_config.py</code>
@@ -101,7 +83,7 @@ Copy in the BUILD file so pants can use your <code>&lt;REPO&gt;/ef_site_config.p
 $ cp ~/workspace/ef-open/getting-started/BUILD.ef_site_config ~/workspace/<REPO>/BUILD.ef_site_config
 ```
 
-Merge and commit <code>ef_site_config.py</code> and <code>BUILD.ef_site_config</code> to your repo.
+Merge and commit <code>ef_site_config.py</code> and <code>BUILD.ef_site_config</code> to your infrastructure repo.
 
 You're customized and ready to build.
 

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -9,7 +9,7 @@ To build the ef-open tools, you will need to...
 
 ### Preliminaries
 
-Below are tl;dr instructions that have worked for the ef_open maintainers.<br>
+Below are tl;dr instructions that have worked for the ef-open maintainers.<br>
 For full details and the latest instructions, see:
 - [Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org
 - [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md) at github.com/pantsbuild

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -58,8 +58,8 @@ $ ./pants -V
 1.2.1
 ```
 
-Edit <code>~/workspace/pants.ini</code> to add these lines to pin the pants version, using the version number found in the previous step.<br>
-Note: If this file is created _before_ pants is installed, pants will self-update if necessary to the desired version and stay there.
+Edit <code>~/workspace/pants.ini</code> to add these lines to pin the pants version, using the version number from the previous step.<br>
+Note: When pants_version is change in pants.ini, pants will self-update if necessary to the desired version and stay there.
 ```
 [GLOBAL]
 pants_version: 1.2.1

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -59,7 +59,7 @@ $ ./pants -V
 ```
 
 Edit <code>~/workspace/pants.ini</code> to add these lines to pin the pants version, using the version number from the previous step.<br>
-Note: When pants_version is change in pants.ini, pants will self-update if necessary to the desired version and stay there.
+Note: When pants_version is changed in pants.ini, pants will self-update if necessary to the desired version and stay there.
 ```
 [GLOBAL]
 pants_version: 1.2.1

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -60,11 +60,22 @@ Check that pants runs, and get its version number
 $ which pants
 /usr/local/bin/pants
 ```
+
 It's on the search path so you shouldn't need to call it out explicitly if this is the only copy you have
 ```
 $ pants -V
 1.2.1
 ```
+If pants won't run on your OS/X installation, take a look at the discussion here:
+[https://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade](https://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade)
+
+For us, this step from the conversation above solved a versioning issue (old version found first) caused by a python path problem in OS/X:<br>
+<code>
+$ sudo cat > /Library/Python/2.7/site-packages/fix_mac_path.pth<br>
+import sys; std_paths=[p for p in sys.path if p.startswith('/System/') and not '/Extras/' in p]; sys.path=[p for p in sys.path if not p.startswith('/System/')]+std_paths<br>
+^D
+</code>
+
 Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using the pants version found in the previous step
 ```
 [GLOBAL]

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -2,35 +2,37 @@
 To build the ef-open tools, you will need to...
  - INSTALL: install pants "at the top directory of the workspace"
    - do this once on every system that will build with pants (your laptop, Jenkins, ...)
- - CUSTOMIZE: create and configure "ef_site_config.py" file and accompanying BUILD.siteconfig file in your infrastructure repo
+ - CUSTOMIZE: configure "ef_site_config.py" in your infrastructure repo, and copy in the provided BUILD.siteconfig
    - do this just once per repo
- - BUILD: export an environment variable to tell pants where ef_site_config.py is, and build
+ - BUILD: export an environment variable to tell pants where ef_site_config.py is, and run pants
    - do this every time you build the tools
-   - ef-open also provides a simple helper script to check the setup and perform the pants build
+   - ef-open also provides a simple example helper script to check the setup and build with pants
 
 ### Preliminaries
 From the pants documentation:
 > To set up pants in your repo, we recommend installing our self-contained pants bash script
-> in the root (ie, "buildroot") of your repo. In this example, ~/workspace is the
-top of all repos. Pants is installed there.
+> in the root (ie, "buildroot") of your repo.
+
+In this example, <code>~/workspace</code> is the top of all repos. Pants is installed there.
 
 For full details and the latest instructions, see
 - [Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org
 - [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io<br>
+- tl;dr-style instructions appear below
 
 #### Assumptions in all examples and instructions below
-- Common directory above all repos is <code>~/workspace</code>
+- The common directory above all repos is <code>~/workspace</code>
 - The ef-open repo is called <code>ef-open</code> at <code>~/workspace/ef-open</code>
-- The company or project's Cloudformation Infrastructure repo is already set up (possibly empty, but it's ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.
+- The company or project's Cloudformation Infrastructure repo is already set up (possibly empty, but ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.<br>
 Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;</code>.
 - Overall structure of stuff discussed here is:<br>
-<code>  ~/workspace <--- Common top-level directory above all repos (pants will be installed here)</code><br>
-<code>  ~/workspace/ef-open <--- ef-open repo, sync'd with ef-open at github</code><br>
-<code>  ~/workspace/&lt;REPO&gt; <--- your infrastructure repo with localized /ef_site_config.py</code><br>
-<code>  &lt;REPO&gt;/ef_site_config.py <--- your project/company-specific ef-open configuration file</code><br>
+<code>  ~/workspace</code> <--- Common top-level directory above all repos (Installed pants here and cd to here to build)<br>
+<code>  ~/workspace/ef-open</code> <--- ef-open repo, sync'd with ef-open at github<br>
+<code>  ~/workspace/&lt;REPO&gt;</code> <--- your infrastructure repo with localized /ef_site_config.py<br>
+<code>  &lt;REPO&gt;/ef_site_config.py</code> <--- your project/company-specific ef-open configuration file<br>
 - To get you started, ef-open provides:<br>
-  <code>ef-open/getting-started/ef_site_config.py <--- starter site config file to copy to &lt;REPO&gt;/ef_site_config.py</code><br>
-  <code>ef-open/getting-started/BUILD.ef_site_config <--- ready-to-go build file to copy to &lt;REPO&gt;/BUILD.ef_site_config</code>
+  <code>ef-open/getting-started/ef_site_config.py</code> <--- starter site config file to copy to &lt;REPO&gt;/ef_site_config.py<br>
+  <code>ef-open/getting-started/BUILD.ef_site_config</code> <--- ready-to-go build file to copy to &lt;REPO&gt;/BUILD.ef_site_config
 
 ### INSTALL: install pants
 *Do this on any system that will build the tools, such as tool maintainers' laptops, and Jenkins*
@@ -108,10 +110,8 @@ ef-open/tools/build-ef-open <REPO>
 
 Example:
 ```bash
-$ MY_REPO=our_infra_repo  # infra repo must be at ~/workspace/$MY_REPO
 $ cd ~/workspace
-~/workspace:$ ef-open/tools/build-ef-open $MY_REPO
-$ ef-open/tools/build-ef-open my-repo
+$ ef-open/tools/build-ef-open our_infra_repo
 ```
 (ignore that fatal message)
 ```

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -16,7 +16,7 @@ above all repos. Pants has a .ini file there, and will make some visible and inv
 directories inside this directory.
 
 For full details and the latest instructions, see
-- [Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org
+- ~~[Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org~~
 - [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io<br>
 - tl;dr-style instructions appear below
 

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -9,16 +9,18 @@ To build the ef-open tools, you will need to...
    - ef-open also provides a simple example helper script to check the setup and build with pants
 
 ### Preliminaries
-These instructions use pip to install pants from Pypi to /usr/local/bin
+As the time this was written, the pants installation instructions at [http://www.pantsbuild.org/install.html](http://www.pantsbuild.org/install.html)
+were not in sync with the newer instructions in the pants repo at [https://github.com/pantsbuild/pants/blob/master/README.md](https://github.com/pantsbuild/pants/blob/master/README.md) and in fact will install an older version of pants.
 
-In the instructions and examples below, <code>~/workspace</code> is the common directory
-above all repos. Pants has a .ini file there, and will make some visible and invisible (dot-file)
-directories inside this directory.
+Accordingly, these instructions use pip to install pants from PyPI to /usr/local/bin, per the note about PyPI in the README.md.
+
+In the instructions and examples below, <code>~/workspace</code> is the common directory above all repos.<br>
+Pants has a .ini file there, and will make some visible and invisible (dot-file) directories inside it.
 
 For full details and the latest instructions, see
-- ~~[Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org~~
-- [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io<br>
-- tl;dr-style instructions appear below
+- [Installing Packages](http://www.pantsbuild.org/install.html) at python.org (for pip, if you don't have it)
+- [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md)
+- [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io<br
 
 #### Assumptions in all examples and instructions below
 - The common directory above all repos is <code>~/workspace</code>
@@ -38,26 +40,29 @@ Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;
 *Do this on any system that will build the tools, such as tool maintainers' laptops, and Jenkins*
 
 <code>cd</code> to the directory above all the repos, which in these examples is <code>~/workspace</code>, then
-Use pip to install pants locally, or chef or other configuration tool to install it on a build server.
-The maintainers of ef-open presently use version 1.2.1 of pants. The BUILD files for ef-open are not complex,
-and will probably work ok with other versions of pants.
+use pip to install pants... or use chef or other configuration tool to install it on a build server.
+
+The maintainers of ef-open currently build ef-open with version 1.2.1 of pants. The BUILD files for ef-open are not complex,
+and will probably work with other versions of pants.
 ```bash
 # to install version 1.2.1 specifically:
 $ cd ~/workspace
 $ sudo pip install pantsbuild.pants==1.2.1
-$ touch pants  # pants demands a file with this name in the cwd, even if the binary is really somewhere else
+$ touch pants  # pants requires a file with this name in the cwd, even if the binary is really somewhere else
 
 # or to install the latest version:
 $ cd ~/workspace
 $ sudo pip install pantsbuild.pants
-$ touch pants  # pants demands a file with this name in the cwd, even if the binary is really somewhere else
+$ touch pants  # pants requires a file with this name in the cwd, even if the binary is really somewhere else
 ```
 
-Check that pants runs, and get the version number of what was just installed
+Check that pants runs, and get its version number
 ```
 $ which pants
 /usr/local/bin/pants
-
+```
+It's on the search path so you shouldn't need to call it out explicitly if this is the only copy you have
+```
 $ pants -V
 1.2.1
 ```
@@ -68,8 +73,8 @@ pants_version: 1.2.1
 ```
 
 Pants is now installed. It should be on your path, so in the examples below we'll
-call it without literally including the path. On a server, you may need or prefer
-to specify the full path to the binary when running pants.
+call it without a path.<br>
+On a build server, you may need or prefer to specify the full path to the pants binary.
 
 ### CUSTOMIZE: configure ef-open for your AWS environment<BR>
 *Do this once for each infrastructure repo*

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -70,11 +70,9 @@ If pants won't run on your OS/X installation, take a look at the discussion here
 [https://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade](https://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade)
 
 For us, this step from the conversation above solved a versioning issue (old version found first) caused by a python path problem in OS/X:<br>
-<code>
-$ sudo cat > /Library/Python/2.7/site-packages/fix_mac_path.pth<br>
-import sys; std_paths=[p for p in sys.path if p.startswith('/System/') and not '/Extras/' in p]; sys.path=[p for p in sys.path if not p.startswith('/System/')]+std_paths<br>
-^D
-</code>
+<code>$ sudo cat > /Library/Python/2.7/site-packages/fix_mac_path.pth</code><br>
+<code>import sys; std_paths=[p for p in sys.path if p.startswith('/System/') and not '/Extras/' in p]; sys.path=[p for p in sys.path if not p.startswith('/System/')]+std_paths</code><br>
+<code>^D</code><br>
 
 Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using the pants version found in the previous step
 ```

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -9,11 +9,11 @@ To build the ef-open tools, you will need to...
    - ef-open also provides a simple example helper script to check the setup and build with pants
 
 ### Preliminaries
-From the pants documentation:
-> To set up pants in your repo, we recommend installing our self-contained pants bash script
-> in the root (ie, "buildroot") of your repo.
+These instructions use pip to install pants from Pypi to /usr/local/bin
 
-In this example, <code>~/workspace</code> is the top of all repos. Pants is installed there.
+In the instructions and examples below, <code>~/workspace</code> is the common directory
+above all repos. Pants has a .ini file there, and will make some visible and invisible (dot-file)
+directories inside this directory.
 
 For full details and the latest instructions, see
 - [Installing Pants](http://www.pantsbuild.org/install.html) at pantsbuild.org
@@ -23,7 +23,7 @@ For full details and the latest instructions, see
 #### Assumptions in all examples and instructions below
 - The common directory above all repos is <code>~/workspace</code>
 - The ef-open repo is called <code>ef-open</code> at <code>~/workspace/ef-open</code>
-- The company or project's Cloudformation Infrastructure repo is already set up (possibly empty, but ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.<br>
+- The company or project's Cloudformation infrastructure repo is already set up (possibly empty, but ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.<br>
 Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;</code>.
 - Overall structure of stuff discussed here is:<br>
 <code>  ~/workspace</code> <--- Common top-level directory above all repos (Installed pants here and cd to here to build)<br>
@@ -38,26 +38,39 @@ Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;
 *Do this on any system that will build the tools, such as tool maintainers' laptops, and Jenkins*
 
 <code>cd</code> to the directory above all the repos, which in these examples is <code>~/workspace</code>, then
-download and install pants:
+Use pip to install pants locally, or chef or other configuration tool to install it on a build server.
+The maintainers of ef-open presently use version 1.2.1 of pants. The BUILD files for ef-open are not complex,
+and will probably work ok with other versions of pants.
 ```bash
+# to install version 1.2.1 specifically:
 $ cd ~/workspace
-$ curl -L -O https://pantsbuild.github.io/setup/pants && chmod +x pants && touch pants.ini
+$ sudo pip install pantsbuild.pants==1.2.1
+$ touch pants  # pants demands a file with this name in the cwd, even if the binary is really somewhere else
+
+# or to install the latest version:
+$ cd ~/workspace
+$ sudo pip install pantsbuild.pants
+$ touch pants  # pants demands a file with this name in the cwd, even if the binary is really somewhere else
 ```
 
-Check that pants runs and get the installed version:
+Check that pants runs, and get the version number of what was just installed
 ```
-$ ./pants -V
-1.1.0
+$ which pants
+/usr/local/bin/pants
+
+pants -V
+1.2.1
 ```
 
 Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using the pants version from the previous step
 ```
 [GLOBAL]
-pants_version: 1.1.0
+pants_version: 1.2.1
 ```
 
-Pants is now installed.
-
+Pants is now installed. It should be on your path, so in the examples below we'll
+call it without literally including the path. On a server, you may need or prefer
+to specify the full path to the binary when running pants.
 
 ### CUSTOMIZE: configure ef-open for your AWS environment<BR>
 *Do this once for each infrastructure repo*
@@ -86,7 +99,7 @@ You're customized and ready to build.
 ```
 $ cd ~/workspace
 $ export EF_SITE_REPO=<REPO>
-$ ./pants binary ef-open/src:
+$ pants binary ef-open/src:
 ```
 
 Tools will be built in ef-open/dist:<br>
@@ -113,7 +126,7 @@ Example:
 $ cd ~/workspace
 $ ef-open/tools/build-ef-open our_infra_repo
 ```
-(ignore that fatal message)
+(ignore the fatal message below)
 ```
 fatal: Not a git repository (or any of the parent directories):
 

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -58,11 +58,10 @@ Check that pants runs, and get the version number of what was just installed
 $ which pants
 /usr/local/bin/pants
 
-pants -V
+$ pants -V
 1.2.1
 ```
-
-Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using the pants version from the previous step
+Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using the pants version found in the previous step
 ```
 [GLOBAL]
 pants_version: 1.2.1

--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -1,18 +1,17 @@
 ## Installing pants and building ef-open tools
 To build the ef-open tools, you will need to...
- - INSTALL: install pants "at the top directory of the workspace"
-   - do this once on every system that will build with pants (your laptop, Jenkins, ...)
- - CUSTOMIZE: configure "ef_site_config.py" in your infrastructure repo, and copy in the provided BUILD.siteconfig
-   - do this just once per repo
- - BUILD: export an environment variable to tell pants where ef_site_config.py is, and run pants
-   - do this every time you build the tools
-   - ef-open also provides a simple example helper script to check the setup and build with pants
+
+| What | Where | When |
+| --- | --- | --- |
+| INSTALL:<br>install pants | on every system that will use pants to build (your laptop, Jenkins, ...) | once per system |
+| CUSTOMIZE:<br>configure "ef_site_config.py" and copy in the provided BUILD.siteconfig | your infrastructure repo(s) | once per repo initially (and any time you need to change a config value in ef_site_config.py) |
+| BUILD:<br>export an environment variable to tell pants where ef_site_config.py is, then run pants<br>_or_<br>use the example script, <code>tools/build-ef-open</code> that checks setup and runs pants | any pants-capable system | every time you build ef-open (whenever there's an update to /src or your revise your ef_site_config.py) |
 
 ### Preliminaries
 As the time this was written, the pants installation instructions at [http://www.pantsbuild.org/install.html](http://www.pantsbuild.org/install.html)
-were not in sync with the newer instructions in the pants repo at [https://github.com/pantsbuild/pants/blob/master/README.md](https://github.com/pantsbuild/pants/blob/master/README.md) and in fact will install an older version of pants.
+were not in sync with the newer instructions in the pants repo at [https://github.com/pantsbuild/pants/blob/master/README.md](https://github.com/pantsbuild/pants/blob/master/README.md) and will install an old version of pants.
 
-Accordingly, these instructions use pip to install pants from PyPI to /usr/local/bin, per the note about PyPI in the README.md.
+Accordingly, these instructions use pip to install pants from PyPI to <code>/usr/local/bin</code> per the PyPI reference in [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md).
 
 In the instructions and examples below, <code>~/workspace</code> is the common directory above all repos.<br>
 Pants has a .ini file there, and will make some visible and invisible (dot-file) directories inside it.
@@ -20,21 +19,21 @@ Pants has a .ini file there, and will make some visible and invisible (dot-file)
 For full details and the latest instructions, see
 - [Installing Packages](http://www.pantsbuild.org/install.html) at python.org (for pip, if you don't have it)
 - [pantsbuild/README.md](https://github.com/pantsbuild/pants/blob/master/README.md)
-- [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io<br
+- [Python Projects with Pants](https://pantsbuild.github.io/python-readme.html) at pandsbuild.github.io
 
 #### Assumptions in all examples and instructions below
 - The common directory above all repos is <code>~/workspace</code>
 - The ef-open repo is called <code>ef-open</code> at <code>~/workspace/ef-open</code>
-- The company or project's Cloudformation infrastructure repo is already set up (possibly empty, but ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.<br>
+- Your company or project's Cloudformation infrastructure repo is already set up (possibly empty, but ready to use) at <code>~/workspace/&lt;REPO&gt;</code>.<br>
 Call it whatever you like. This documentation refers to it as <code>&lt;REPO&gt;</code>.
 - Overall structure of stuff discussed here is:<br>
 <code>  ~/workspace</code> <--- Common top-level directory above all repos (Installed pants here and cd to here to build)<br>
 <code>  ~/workspace/ef-open</code> <--- ef-open repo, sync'd with ef-open at github<br>
-<code>  ~/workspace/&lt;REPO&gt;</code> <--- your infrastructure repo with localized /ef_site_config.py<br>
+<code>  ~/workspace/&lt;REPO&gt;</code> <--- your infrastructure repo containing the localized <code>/ef_site_config.py</code><br>
 <code>  &lt;REPO&gt;/ef_site_config.py</code> <--- your project/company-specific ef-open configuration file<br>
 - To get you started, ef-open provides:<br>
-  <code>ef-open/getting-started/ef_site_config.py</code> <--- starter site config file to copy to &lt;REPO&gt;/ef_site_config.py<br>
-  <code>ef-open/getting-started/BUILD.ef_site_config</code> <--- ready-to-go build file to copy to &lt;REPO&gt;/BUILD.ef_site_config
+  <code>ef-open/getting-started/ef_site_config.py</code> <--- starter site config file to copy to <code>&lt;REPO&gt;/ef_site_config.py</code> and then customize<br>
+  <code>ef-open/getting-started/BUILD.ef_site_config</code> <--- ready-to-go build file to copy to <code>&lt;REPO&gt;/BUILD.ef_site_config</code>
 
 ### INSTALL: install pants
 *Do this on any system that will build the tools, such as tool maintainers' laptops, and Jenkins*
@@ -45,12 +44,12 @@ use pip to install pants... or use chef or other configuration tool to install i
 The maintainers of ef-open currently build ef-open with version 1.2.1 of pants. The BUILD files for ef-open are not complex,
 and will probably work with other versions of pants.
 ```bash
-# to install version 1.2.1 specifically:
+# to install version 1.2.1 specifically, using pip:
 $ cd ~/workspace
 $ sudo pip install pantsbuild.pants==1.2.1
 $ touch pants  # pants requires a file with this name in the cwd, even if the binary is really somewhere else
 
-# or to install the latest version:
+# or to install the latest version, using pip:
 $ cd ~/workspace
 $ sudo pip install pantsbuild.pants
 $ touch pants  # pants requires a file with this name in the cwd, even if the binary is really somewhere else
@@ -72,9 +71,9 @@ Edit ~/workspace/pants.ini to pin the pants version by adding these lines, using
 pants_version: 1.2.1
 ```
 
-Pants is now installed. It should be on your path, so in the examples below we'll
+Pants is now installed. If you installed with pip, it's on probably your path, so in the examples below we'll
 call it without a path.<br>
-On a build server, you may need or prefer to specify the full path to the pants binary.
+On a build server, you may need or prefer to always specify the full path to the pants binary.
 
 ### CUSTOMIZE: configure ef-open for your AWS environment<BR>
 *Do this once for each infrastructure repo*
@@ -85,7 +84,7 @@ $ cp ~/workspace/ef-open/getting-started/ef_site_config.py ~/workspace/<REPO>/ef
 ```
 Define custom values for your tooling
 - edit <code>~/workspace/&lt;REPO&gt;/ef_site_config.py</code>
-- localize all values for the company/project following the examples in comments there
+- localize all values for the company/project following the examples in comments in the file
 - save the updated <code>~/workspace/&lt;REPO&gt;/ef_site_config.py</code>
 
 Copy in the BUILD file so pants can use your <code>&lt;REPO&gt;/ef_site_config.py</code>

--- a/tools/build-ef-open
+++ b/tools/build-ef-open
@@ -17,7 +17,7 @@ usage() {
 
 [ -n "$1" ] || fail "$(usage)"
 
-[ -x "${PANTS}" ] || fail "No pants executable at ${PANTS}"
+[ -x "${PANTS}" ] || fail "No pants executable at ${PANTS}. Run this tool from the directory above all repos."
 
 # INFRA_REPO may have been spec'd w/ a trailing slash. Remove it.
 INFRA_REPO=${1%/}

--- a/tools/build-ef-open
+++ b/tools/build-ef-open
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 declare -r SITE_CONFIG_FILE_NAME=ef_site_config.py
-declare -r PANTS=/usr/local/bin/pants
+declare -r PANTS=./pants
 
 fail() {
   echo -e "$1"
@@ -38,7 +38,7 @@ popd >/dev/null
 
 # build
 export EF_SITE_REPO=${INFRA_REPO}
-pants binary ef-open/src:
+${PANTS} binary ef-open/src:
 [ $? -eq 0 ] || fail "Build failed"
 
 # rename files to remove .pex extension

--- a/tools/build-ef-open
+++ b/tools/build-ef-open
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -r SITE_CONFIG_FILE_NAME=ef_site_config.py
+declare -r PANTS=/usr/local/bin/pants
 
 fail() {
   echo -e "$1"
@@ -15,6 +16,8 @@ usage() {
 }
 
 [ -n "$1" ] || fail "$(usage)"
+
+[ -x "${PANTS}" ] || fail "No pants executable at ${PANTS}"
 
 # INFRA_REPO may have been spec'd w/ a trailing slash. Remove it.
 INFRA_REPO=${1%/}
@@ -35,7 +38,7 @@ popd >/dev/null
 
 # build
 export EF_SITE_REPO=${INFRA_REPO}
-./pants binary ef-open/src:
+pants binary ef-open/src:
 [ $? -eq 0 ] || fail "Build failed"
 
 # rename files to remove .pex extension

--- a/tools/build-ef-open
+++ b/tools/build-ef-open
@@ -34,7 +34,7 @@ popd >/dev/null
 [ -r ${SITE_CONFIG_FILESPEC} ] || fail "can't read ${SITE_CONFIG_FILE_NAME} at ${INFRA_REPO}/"
 
 # build
-EF_SITE_REPO=${INFRA_REPO}
+export EF_SITE_REPO=${INFRA_REPO}
 ./pants binary ef-open/src:
 [ $? -eq 0 ] || fail "Build failed"
 


### PR DESCRIPTION
## Ready state
Ready

## Synopsis
- export the env var EF_SITE_REPO so pants can access it
- ~~update installation instructions to install pants using pip, and clarify some other stuff.~~
- clean up installation instructions using the curl-based install and relying on pants auto-update