### PR TITLE
S3 acls

### DIFF
--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -134,7 +134,7 @@ def main():
 
   # Service must exist in service registry
   if context.service_registry.service_record(service_name) is None:
-    fail("service: {} not found in service registry: {}".format(service_name, context.service_registry.filespec()))
+    fail("service: {} not found in service registry: {}".format(service_name, context.service_registry.filespec))
 
   if not context.env_full in context.service_registry.valid_envs(service_name):
     fail("Invalid environment: {} for service_name: {}\nValid environments are: {}" \

--- a/src/ef-version.py
+++ b/src/ef-version.py
@@ -483,7 +483,7 @@ def cmd_set(context):
     print("would set key: {} with value: {} {}".format(s3_key, context.value, s3_version_status))
   else:
     context.aws_client("s3").put_object(
-      ACL = 'private',
+      ACL = 'bucket-owner-read',
       Body = context.value,
       Bucket = EFConfig.S3_VERSION_BUCKET,
       ContentEncoding = EFConfig.S3_VERSION_CONTENT_ENCODING,


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
ef-version writes objects that may exist in buckets that are shared across accounts. Objects written by an account that does not own the bucket should allow read permissions to the account that owns the bucket.

Use case: bucket owner wants to reference a version written by another account

## Changelog
* use bucket-owner-read ACL when executing put_object
* bug fix, filespec is not callable

