### PR TITLE
Allow encrypted values

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Ready State
+> Valid states are:
+> Ready - This PR is ready to be reviewed.
+> Not Ready - Please provide an explanation.
+**Ready**
+## Synopsis
+> Include a brief description of the overall point of this PR and a link to the ticket.
+[CXOPS-XXXX](https://ellation.atlassian.net/browse/CXOPS-XXXX)
+## Changelog
+> Brief summary of changes which should be included in your commit messages.
+## Dependencies
+> List any items which need to be in place for this review, such as which machines must running or any software 
+> packages needed.
+## Linked PRs
+> Include links to any other PRs that are related to this one.
+## Testing
+> Include instructions for testing this PR.  The format of this should be numbered bullets (use `1.` for each bullet
+> in your markdown) with sub-bullets for assertions.  Bug fixes should 
+> contain instructions for confirming the bug before confirming the fix.  Please include screenshots and explanations 
+> of jargon where appropriate.
+1. Example testing instruction: Load some page.
+  * Assert the HTTP status is 200.
+  * Assert the body of the response contains some text.
+1. A second example step.
+###### [Markdown support](https://guides.github.com/features/mastering-markdown/)

--- a/src/ef_app_config_reader.py
+++ b/src/ef_app_config_reader.py
@@ -28,12 +28,11 @@ class EFAppConfigReader:
   e.g.: default (if present) - superseded by proto (if present) - superseded by proto<N> (if present)
   or: default (if present) - superseded by staging or prod (if present)
   """
-  def __init__(self, env, service, logging, clients):
+  def __init__(self, env, service, clients):
     """
     Args:
       env: the environment to resolve values for
       service: "all" or "<service">
-      logging: a logger
       clients: a dict of AWS clients, with at least "s3"
     Raises:
       botocore.exceptions.ClientError if config
@@ -41,7 +40,6 @@ class EFAppConfigReader:
     self.clients = clients
     self.env = env
     self.env_short = get_env_short(env)
-    self.logging = logging
     self.parameters = None
     self.service = service
 
@@ -102,7 +100,7 @@ import boto3
 def main():
   session = boto3.Session(profile_name="ellationeng", region_name="us-west-2")
   clients = {"s3": session.client("s3") }
-  configreader = EFAppConfigReader("staging", "qc-pulls", None, clients)
+  configreader = EFAppConfigReader("staging", "qc-pulls", clients)
   print("remote username")
   print(configreader.get_value("remote_username"))
 

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -458,6 +458,20 @@ class EFAwsResolver(object):
       else:
         return default
 
+  def kms_decrypt_value(self, lookup, default=None):
+    """
+    Args:
+      lookup: the encrypted value to be decrypted by KMS; base64 encoded
+      default: the optional value to return if lookup failed; returns None if not set
+    Returns:
+      The decrypted key value
+    """
+    try:
+      decrypted_value = EFAwsResolver.__CLIENTS["kms"].decrypt(
+        CiphertextBlob=lookup.decode('base64'))['Plaintext'].decode("utf-8")
+    except ClientError:
+      return default
+    return decrypted_value
 
   def lookup(self, token):
     try:
@@ -478,6 +492,8 @@ class EFAwsResolver(object):
       return self.ec2_elasticip_elasticip_ipaddress(*kv[1:])
     elif kv[0] == "ec2:eni/eni-id":
       return self.ec2_eni_eni_id(*kv[1:])
+    elif kv[0] == "kms:key":
+      return self.kms_decrypt_value(*kv[1:])
     elif kv[0] == "ec2:route-table/main-route-table-id":
       return self.ec2_route_table_main_route_table_id(*kv[1:])
     elif kv[0] == "ec2:security-group/security-group-id":

--- a/src/ef_service_registry.py
+++ b/src/ef_service_registry.py
@@ -49,7 +49,10 @@ class EFServiceRegistry(object):
       raise IOError("Not a file: {}".format(self._service_registry_file))
     # Read the service registry
     service_registry_fh = open(self._service_registry_file, "r")
-    self.service_registry_json = json.load(service_registry_fh)
+    try:
+      self.service_registry_json = json.load(service_registry_fh)
+    except ValueError:
+      raise Exception("Malformed service registry file")
     # Validate service registry
     # 1. All service groups listed in EFConfig.SERVICE_GROUPS must be present
     for service_group in EFConfig.SERVICE_GROUPS:

--- a/src/ef_template_resolver.py
+++ b/src/ef_template_resolver.py
@@ -29,7 +29,7 @@ from ef_version_resolver import EFVersionResolver
 
 # CONSTANTS
 # pattern to find resolvable symbols - finds innermost nestings
-SYMBOL_PATTERN = r'{{([0-9A-Za-z/_,.:\-]+?)}}'
+SYMBOL_PATTERN = r'{{([0-9A-Za-z/_,.:\-\+=]+?)}}'
 # inverse of SYMBOL_PATTERN, and disallows ':' and ',' from param keys; this is checked in load()
 ILLEGAL_PARAMETER_CHARS = r'[^(0-9A-Za-z/_.\-)]'
 

--- a/src/ef_template_resolver.py
+++ b/src/ef_template_resolver.py
@@ -234,7 +234,8 @@ class EFTemplateResolver(object):
       # Create clients - if accessing by role, profile should be None
       try:
         EFTemplateResolver.__CLIENTS = create_aws_clients(self.resolved["REGION"], profile,
-                                        "cloudformation", "cloudfront", "ec2", "iam", "lambda", "route53", "s3", "waf")
+                                        "cloudformation", "cloudfront", "ec2", "iam", "kms",
+                                                          "lambda", "route53", "s3", "waf")
       except RuntimeError as error:
         fail("Exception logging in with Session()", error)
 


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Allows us to use encrypted values in our cloud formation templates for database passwords and other info we don't want stored in plain text. 
## Changelog
- Add '+=' to valid symbols so that b64 encoded values are found during template resolution
- Add kms to instantiated aws clients
- Kms decryption method 
## Testing
Used this [test cf template](https://gist.github.com/dlutsch/82b2e50ebf553c7fb840707e109360b6)
```
± |master {2} ?:3 ✗| → ../ef-open/src/ef-cf.py core-auth.json alpha0 --verbose
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
service_name: core-auth
env: alpha0
env_full: alpha0
env_short: alpha
template_file: core-auth.json
parameter_file: /../parameters/core-auth.parameters.alpha0.json
profile: codemobs
whereami: local
service type: http_service
{'INSTANCE_ID': None, 'ACCOUNT': '490645551402', 'ROLE': None, 'SERVICE': 'core-auth', 'ENV': 'alpha0', 'ACCOUNT_ALIAS': 'codemobs', 'REGION': 'us-west-2', 'ENV_FULL': 'alpha0', 'FUNCTION_NAME': None, 'ENV_SHORT': 'alpha'}
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "alpha0-core-auth",
  "Parameters": {
    "MyPassword": {
      "Type": "String",
      "Default": "Hello World!"
    }
  },
  "Conditions": {
    "EnvIsNotProd": { "Fn::Not": [ { "Fn::Equals": [ "alpha0", "prod" ] } ] }
  },
  "Resources": {
    "LaunchConfig": {
      "Type": "AWS::AutoScaling::LaunchConfiguration",
      "Properties": {
        "ImageId": "test",
        "InstanceType": "t2.small",
        "IamInstanceProfile": "alpha0-core-auth",
        "SecurityGroups": ["test"],
        "AssociatePublicIpAddress": "true"
      },
      "Metadata": {
      "mypassword": { "Ref": "MyPassword" }
      }
    }
  }
}

Validating template
Template passed validation
```
Template is rendered and decrypted value is shown in parameters