### PR TITLE
Provide PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Ready State
+> Valid states are:
+> Ready - This PR is ready to be reviewed.
+> Not Ready - Please provide an explanation.
+**Ready**
+## Synopsis
+> Include a brief description of the overall point of this PR and a link to the ticket.
+[CXOPS-XXXX](https://ellation.atlassian.net/browse/CXOPS-XXXX)
+## Changelog
+> Brief summary of changes which should be included in your commit messages.
+## Dependencies
+> List any items which need to be in place for this review, such as which machines must running or any software 
+> packages needed.
+## Linked PRs
+> Include links to any other PRs that are related to this one.
+## Testing
+> Include instructions for testing this PR.  The format of this should be numbered bullets (use `1.` for each bullet
+> in your markdown) with sub-bullets for assertions.  Bug fixes should 
+> contain instructions for confirming the bug before confirming the fix.  Please include screenshots and explanations 
+> of jargon where appropriate.
+1. Example testing instruction: Load some page.
+  * Assert the HTTP status is 200.
+  * Assert the body of the response contains some text.
+1. A second example step.
+###### [Markdown support](https://guides.github.com/features/mastering-markdown/)


### PR DESCRIPTION
Easier than cut-n-pasting the [Pull Request Description Template](https://ellation.atlassian.net/wiki/display/DEVOPS/Contributing#Contributing-PullRequestDescriptionTemplate) every time

As discussed in [Issue and Pull Request templates](https://github.com/blog/2111-issue-and-pull-request-templates) and documented in [Helping people contribute to your project](https://help.github.com/articles/helping-people-contribute-to-your-project/) / [Creating a pull request template for your repository](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/)