### PR TITLE
EF-Password

### DIFF
--- a/doc/installing-pants-and-building-ef-open.md
+++ b/doc/installing-pants-and-building-ef-open.md
@@ -103,6 +103,7 @@ Tools will be built in ef-open/dist:<br>
   ef-cf.pex
   ef-check-config.pex
   ef-generate.pex
+  ef-password.pex
   ef-resolve-config.pex
   ef-version.pex
 ```
@@ -172,6 +173,7 @@ fatal: Not a git repository (or any of the parent directories):
                    created pex copy dist/ef-cf.pex
                    created pex copy dist/ef-check-config.pex
                    created pex copy dist/ef-generate.pex
+                   created pex copy dist/ef-password.pex
                    created pex copy dist/ef-resolve-config.pex
                    created pex copy dist/ef-version.pex
 15:28:37 00:00     [jvm]

--- a/src/BUILD
+++ b/src/BUILD
@@ -37,6 +37,15 @@ python_binary(
 )
 
 python_binary(
+  name = 'ef-password',
+  source = 'ef-password.py',
+  dependencies = [
+    ':boto3',
+    ':ef-open-lib'
+  ]
+)
+
+python_binary(
   name = 'ef-resolve-config',
   source = 'ef-resolve-config.py',
   dependencies = [

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -116,7 +116,7 @@ def main():
 
     if context.decrypt:
         decrypted_password = ef_utils.kms_decrypt(kms_client=clients['kms'], secret=context.decrypt)
-        print(decrypted_password)
+        print("Decrypted Secret: {}".format(decrypted_password))
         return
 
     if context.plaintext:

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -2,12 +2,9 @@
 
 from __future__ import print_function
 import argparse
-import base64
 import os
 import string
 import sys
-
-from botocore.exceptions import ClientError
 
 from ef_config import EFConfig
 from ef_context import EFContext

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -12,122 +12,122 @@ import ef_utils
 
 
 class EFPWContext(EFContext):
-    def __init__(self):
-        super(EFPWContext, self).__init__()
-        self._decrypt = None
-        self._length = 32
-        self._plaintext = None
+  def __init__(self):
+    super(EFPWContext, self).__init__()
+    self._decrypt = None
+    self._length = 32
+    self._plaintext = None
 
-    @property
-    def decrypt(self):
-        """String value if the tool should decrypt rather than generating a new encrypted secret"""
-        return self._decrypt
+  @property
+  def decrypt(self):
+    """String value if the tool should decrypt rather than generating a new encrypted secret"""
+    return self._decrypt
 
-    @decrypt.setter
-    def decrypt(self, value):
-        if type(value) is not str:
-            raise TypeError("decrypt value must be str")
-        self._decrypt = value
+  @decrypt.setter
+  def decrypt(self, value):
+    if type(value) is not str:
+      raise TypeError("decrypt value must be str")
+    self._decrypt = value
 
-    @property
-    def length(self):
-        """Integer length of the secret to be generated"""
-        return self._length
+  @property
+  def length(self):
+    """Integer length of the secret to be generated"""
+    return self._length
 
-    @length.setter
-    def length(self, value):
-        if not value.isdigit():
-            raise ValueError("length value must be int")
-        elif int(value) < 10:
-            raise ValueError("length value must be >= 10")
-        else:
-            self._length = int(value)
+  @length.setter
+  def length(self, value):
+    if type(value) is not int and not value.isdigit():
+      raise ValueError("length value must be int")
+    elif int(value) < 10:
+      raise ValueError("length value must be >= 10")
+    else:
+      self._length = int(value)
 
-    @property
-    def plaintext(self):
-        """String value of the user-provided secret to be encrypted"""
-        return self._plaintext
+  @property
+  def plaintext(self):
+    """String value of the user-provided secret to be encrypted"""
+    return self._plaintext
 
-    @plaintext.setter
-    def plaintext(self, value):
-        if type(value) is not str:
-            raise TypeError("plaintext value must be str")
-        if sys.getsizeof(value) > 4096:
-            raise ValueError("plaintext value may not be larger than 4kb")
-        self._plaintext = value
+  @plaintext.setter
+  def plaintext(self, value):
+    if type(value) is not str:
+      raise TypeError("plaintext value must be str")
+    if sys.getsizeof(value) > 4096:
+      raise ValueError("plaintext value may not be larger than 4kb")
+    self._plaintext = value
 
 
 def generate_secret(length=32):
-    """
-    Generate a random secret consisting of mixed-case letters and numbers
-    Args:
-        length (int): Length of the generated password
-    Returns:
-        a randomly generated secret string
-    Raises:
-        None
-    """
-    alphabet = string.ascii_letters + string.digits
-    random_bytes = os.urandom(length)
-    indices = [int(len(alphabet) * (ord(byte) / 256.0)) for byte in random_bytes]
-    return "".join([alphabet[index] for index in indices])
+  """
+  Generate a random secret consisting of mixed-case letters and numbers
+  Args:
+      length (int): Length of the generated password
+  Returns:
+      a randomly generated secret string
+  Raises:
+      None
+  """
+  alphabet = string.ascii_letters + string.digits
+  random_bytes = os.urandom(length)
+  indices = [int(len(alphabet) * (ord(byte) / 256.0)) for byte in random_bytes]
+  return "".join([alphabet[index] for index in indices])
 
 
 def handle_args_and_set_context(args):
-    """
-    Args:
-        args: the command line args, probably passed from main() as sys.argv[1:]
-    Returns:
-        a populated EFPWContext object
-    Raises:
-        RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
-        ValueError: if a parameter is invalid
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument("service", help="name of service password is being generated for")
-    parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
-    parser.add_argument("--length", help="length of generated password (default 32)", default=32)
-    parser.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
-    parser.add_argument("--plaintext", help="secret to be encrypted rather than a randomly generated one", default="")
-    parsed_args = vars(parser.parse_args(args))
-    context = EFPWContext()
-    try:
-        context.env = parsed_args["env"]
-    except ValueError as e:
-        ef_utils.fail("Error in env: {}".format(e.message))
-    context.service = parsed_args["service"]
-    context.decrypt = parsed_args["decrypt"]
-    context.length = parsed_args["length"]
-    context.plaintext = parsed_args["plaintext"]
-    return context
+  """
+  Args:
+      args: the command line args, probably passed from main() as sys.argv[1:]
+  Returns:
+      a populated EFPWContext object
+  Raises:
+      RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
+      ValueError: if a parameter is invalid
+  """
+  parser = argparse.ArgumentParser()
+  parser.add_argument("service", help="name of service password is being generated for")
+  parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
+  parser.add_argument("--length", help="length of generated password (default 32)", default=32)
+  parser.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
+  parser.add_argument("--plaintext", help="secret to be encrypted rather than a randomly generated one", default="")
+  parsed_args = vars(parser.parse_args(args))
+  context = EFPWContext()
+  try:
+    context.env = parsed_args["env"]
+  except ValueError as e:
+    ef_utils.fail("Error in env: {}".format(e.message))
+  context.service = parsed_args["service"]
+  context.decrypt = parsed_args["decrypt"]
+  context.length = parsed_args["length"]
+  context.plaintext = parsed_args["plaintext"]
+  return context
 
 
 def main():
-    context = handle_args_and_set_context(sys.argv[1:])
-    profile = None if context.whereami == "ec2" else context.account_alias
+  context = handle_args_and_set_context(sys.argv[1:])
+  profile = None if context.whereami == "ec2" else context.account_alias
 
-    try:
-        clients = ef_utils.create_aws_clients(EFConfig.DEFAULT_REGION, profile, "kms")
-    except RuntimeError as error:
-        ef_utils.fail(
-            "Exception creating clients in region {} with profile {}".format(EFConfig.DEFAULT_REGION, profile),
-            error
-        )
+  try:
+    clients = ef_utils.create_aws_clients(EFConfig.DEFAULT_REGION, profile, "kms")
+  except RuntimeError as error:
+    ef_utils.fail(
+      "Exception creating clients in region {} with profile {}".format(EFConfig.DEFAULT_REGION, profile),
+      error
+    )
 
-    if context.decrypt:
-        decrypted_password = ef_utils.kms_decrypt(kms_client=clients['kms'], secret=context.decrypt)
-        print("Decrypted Secret: {}".format(decrypted_password))
-        return
-
-    if context.plaintext:
-        password = context.plaintext
-    else:
-        password = generate_secret(context.length)
-        print("Generated Secret: {}".format(password))
-    encrypted_password = ef_utils.kms_encrypt(clients['kms'], context.service, context.env, password)
-    print("Encrypted Secret: {}".format(encrypted_password))
+  if context.decrypt:
+    decrypted_password = ef_utils.kms_decrypt(kms_client=clients['kms'], secret=context.decrypt)
+    print("Decrypted Secret: {}".format(decrypted_password))
     return
 
-if __name__ == "__main__":
-    main()
+  if context.plaintext:
+    password = context.plaintext
+  else:
+    password = generate_secret(context.length)
+    print("Generated Secret: {}".format(password))
+  encrypted_password = ef_utils.kms_encrypt(clients['kms'], context.service, context.env, password)
+  print("Encrypted Secret: {}".format(encrypted_password))
+  return
 
+
+if __name__ == "__main__":
+  main()

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -65,6 +65,8 @@ def generate_secret(length):
         length (int): Length of the generated password
     Returns:
         a randomly generated secret string
+    Raises:
+        None
     """
     alphabet = string.ascii_letters + string.digits
     random_bytes = os.urandom(length)
@@ -81,9 +83,9 @@ def kms_encrypt(kms_client, service, env, secret):
         env (string): environment that the secret is being encrypted for.
         secret (string): value to be encrypted
     Returns:
-        a populated EFPWContext object
+        an encrypted secret string
     Raises:
-        None
+        SystemExit: when providing custom output for a caught exception
     """
     try:
         response = kms_client.encrypt(
@@ -105,9 +107,9 @@ def kms_decrypt(kms_client, secret):
         kms_client (boto3 kms client object): Usually created through ef_utils.create_aws_clients.
         secret (string): base64 encoded value to be decrypted
     Returns:
-        a populated EFPWContext object
+        a decrypted copy of secret string
     Raises:
-        None
+        SystemExit: when providing custom output for a caught exception
     """
     try:
         decrypted_secret = kms_client.decrypt(CiphertextBlob=base64.b64decode(secret))['Plaintext']

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import argparse
+import base64
+import os
+import string
+import sys
+
+from botocore.exceptions import ClientError
+
+from ef_config import EFConfig
+from ef_context import EFContext
+from ef_utils import create_aws_clients, fail
+
+
+class EFPWContext(EFContext):
+    def __init__(self):
+        super(EFPWContext, self).__init__()
+        self._decrypt = None
+        self._length = None
+        self._plaintext = None
+
+    @property
+    def decrypt(self):
+        """String value if the tool should decrypt rather than generating a new encrypted secret"""
+        return self._decrypt
+
+    @decrypt.setter
+    def decrypt(self, value):
+        if type(value) is not str:
+            raise TypeError("decrypt value must be str")
+        self._decrypt = value
+
+    @property
+    def length(self):
+        """Integer length of the secret to be generated"""
+        return self._length
+
+    @length.setter
+    def length(self, value):
+        try:
+            self._length = int(value)
+        except ValueError:
+            raise ValueError("length value must be int")
+
+    @property
+    def plaintext(self):
+        """String value of the user-provided secret to be encrypted"""
+        return self._plaintext
+
+    @plaintext.setter
+    def plaintext(self, value):
+        if type(value) is not str:
+            raise TypeError("plaintext value must be str")
+        if sys.getsizeof(value) > 4096:
+            raise ValueError("plaintext value may not be larger than 4kb")
+        self._plaintext = value
+
+
+def generate_secret(length):
+    """
+    Generate a random secret consisting of mixed-case letters and numbers
+    Args:
+        length (int): Length of the generated password
+    Returns:
+        a randomly generated secret string
+    """
+    alphabet = string.ascii_letters + string.digits
+    random_bytes = os.urandom(length)
+    indices = [int(len(alphabet) * (ord(byte) / 256.0)) for byte in random_bytes]
+    return "".join([alphabet[index] for index in indices])
+
+
+def kms_encrypt(kms_client, service, env, secret):
+    """
+    Encrypt string for use by a given service/environment
+    Args:
+        kms_client (boto3 kms client object): Usually created through ef_utils.create_aws_clients.
+        service (string): name of the service that the secret is being encrypted for.
+        env (string): environment that the secret is being encrypted for.
+        secret (string): value to be encrypted
+    Returns:
+        a populated EFPWContext object
+    Raises:
+        None
+    """
+    try:
+        response = kms_client.encrypt(
+            KeyId='alias/{}-{}'.format(env, service),
+            Plaintext=secret.encode()
+        )
+    except ClientError as error:
+        if error.response['Error']['Code'] == "NotFoundException":
+            fail("Key '{}-{}' not found. You may need to run ef-generate for this environment.".format(env, service), error)
+        fail("boto3 exception occurred while performing encrypt operation.", error)
+    encrypted_secret = base64.b64encode(response['CiphertextBlob'])
+    return encrypted_secret
+
+
+def kms_decrypt(kms_client, secret):
+    """
+    Decrypt kms-encrypted string
+    Args:
+        kms_client (boto3 kms client object): Usually created through ef_utils.create_aws_clients.
+        secret (string): base64 encoded value to be decrypted
+    Returns:
+        a populated EFPWContext object
+    Raises:
+        None
+    """
+    try:
+        decrypted_secret = kms_client.decrypt(CiphertextBlob=base64.b64decode(secret))['Plaintext']
+    except TypeError:
+        fail("Malformed base64 string data")
+    except ClientError as error:
+        if error.response["Error"]["Code"] == "InvalidCiphertextException":
+            fail("The decrypt request was rejected because the specified ciphertext \
+            has been corrupted or is otherwise invalid.", error)
+        if error.response["Error"]["Code"] == "NotFoundException":
+            fail("The decrypt request was rejected because the specified entity or resource could not be found.", error)
+        fail("boto3 exception occurred while performing decrypt operation.", error)
+    return decrypted_secret
+
+
+def handle_args_and_set_context(args):
+    """
+    Args:
+        args: the command line args, probably passed from main() as sys.argv[1:]
+    Returns:
+        a populated EFPWContext object
+    Raises:
+        RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
+        ValueError: if a parameter is invalid
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("service", help="name of service password is being generated for")
+    parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
+    parser.add_argument("--length", help="length of generated password (default 32)", default=32)
+    parser.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
+    parser.add_argument("--plaintext", help="secret to be encrypted rather than a randomly generated one", default="")
+    parsed_args = vars(parser.parse_args(args))
+    context = EFPWContext()
+    try:
+        context.env = parsed_args["env"]
+    except ValueError as e:
+        fail("Error in env: {}".format(e.message))
+    context.service = parsed_args["service"]
+    context.decrypt = parsed_args["decrypt"]
+    context.length = parsed_args["length"]
+    context.plaintext = parsed_args["plaintext"]
+    return context
+
+
+def main():
+    context = handle_args_and_set_context(sys.argv[1:])
+    profile = None if context.whereami == "ec2" else context.account_alias
+
+    try:
+        clients = create_aws_clients(EFConfig.DEFAULT_REGION, profile, "kms")
+    except RuntimeError as error:
+        fail("Exception creating clients in region {} with profile {}".format(EFConfig.DEFAULT_REGION, profile), error)
+
+    if context.decrypt:
+        decrypted_password = kms_decrypt(kms_client=clients['kms'], secret=context.decrypt)
+        print(decrypted_password)
+        return
+
+    if context.plaintext:
+        password = context.plaintext
+    else:
+        password = generate_secret(context.length)
+        print("Generated Secret: {}".format(password))
+    encrypted_password = kms_encrypt(clients['kms'], context.service, context.env, password)
+    print("Encrypted Secret: {}".format(encrypted_password))
+    return
+
+if __name__ == "__main__":
+    main()
+

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -36,12 +36,12 @@ class EFPWContext(EFContext):
 
     @length.setter
     def length(self, value):
-        try:
-            if int(value) < 10:
-                raise ValueError("length value must be >= 10")
+        if not value.isdigit():
+            raise ValueError("length value must be int")
+        elif int(value) < 10:
+            raise ValueError("length value must be >= 10")
+        else:
             self._length = int(value)
-        except TypeError:
-            raise TypeError("length value must be int")
 
     @property
     def plaintext(self):

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -63,7 +63,7 @@ def http_get_metadata(metadata_path, timeout=__HTTP_DEFAULT_TIMEOUT_SEC):
   try:
     response = urllib2.urlopen(metadata_path, None, timeout)
     if response.getcode() != 200:
-      raise IOError("Non-200 response " + response.getcode() + " reading " + metadata_path)
+      raise IOError("Non-200 response " + str(response.getcode()) + " reading " + metadata_path)
     return response.read()
   except urllib2.URLError as error:
     raise IOError("URLError in http_get_string: " + repr(error))

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -56,19 +56,19 @@ class TestEFPassword(unittest.TestCase):
     def test_args_invalid_env(self):
         """Verify that an invalid environment arg raises an exception"""
         args = [self.service, "invalid_env"]
-        with self.assertRaises((SystemExit, ValueError)):
+        with self.assertRaises(SystemExit):
             ef_password.handle_args_and_set_context(args)
 
     def test_args_nonint_length(self):
         """A non-integer value for the length param should raise an exception"""
         args = [self.service, self.env, "--length", "8a"]
-        with self.assertRaises((SystemExit, ValueError)):
+        with self.assertRaises(ValueError):
             ef_password.handle_args_and_set_context(args)
 
     def test_args_length_too_small(self):
         """A length value less than 10 should raise an exception"""
         args = [self.service, self.env, "--length", "5"]
-        with self.assertRaises((SystemExit, ValueError)):
+        with self.assertRaises(ValueError):
             ef_password.handle_args_and_set_context(args)
 
     @patch('ef-password.generate_secret', return_value="mock_secret")

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -1,0 +1,81 @@
+"""
+Copyright 2016-2017 Ellation, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import base64
+import unittest
+
+from botocore.exceptions import ClientError
+from mock import Mock, patch
+
+import context_paths
+ef_password = __import__("ef-password")
+
+
+class TestEFGenerate(unittest.TestCase):
+
+    def setUp(self):
+        self.service = "test-service"
+        self.env = "test0"
+        self.secret = "secret"
+        self.error_response = {'Error': {'Code': 'FakeError', 'Message': 'Testing catch of all ClientErrors'}}
+        self.client_error = ClientError(self.error_response, "boto3")
+        self.mock_kms = Mock(name="mocked kms client")
+        self.bytes_return = "cipher_blob".encode()
+        self.mock_kms.encrypt.return_value = {"CiphertextBlob": self.bytes_return}
+        self.mock_kms.decrypt.return_value = {"Plaintext": self.bytes_return}
+
+    def test_generate_secret(self):
+        """Check that generated secret matches the length specified and doesn't contain any special characters"""
+        random_secret = ef_password.generate_secret(24)
+        self.assertEqual(len(random_secret), 24)
+        assert not set('[~!@#$%^&*()_+{}":;\']+$').intersection(random_secret)
+
+    def test_kms_encrypt_call(self):
+        """Validates basic kms call parameters"""
+        ef_password.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+        self.mock_kms.encrypt.assert_called_once_with(
+            KeyId='alias/{}-{}'.format(self.env, self.service),
+            Plaintext=self.secret.encode()
+        )
+
+    def test_kms_encrypt_returns_b64(self):
+        """Validate that function returns a base64 encoded value"""
+        encrypted_secret = ef_password.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+        b64_return = base64.b64encode(self.bytes_return)
+        self.assertEqual(b64_return, encrypted_secret)
+
+    def test_kms_encrypt_fails_client_error(self):
+        """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
+        self.mock_kms.encrypt.side_effect = self.client_error
+        with self.assertRaises((SystemExit, ClientError)):
+            ef_password.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+
+    def test_kms_decrypt_call(self):
+        """Validates basic kms call parameters"""
+        b64_secret = base64.b64encode(self.secret)
+        ef_password.kms_decrypt(self.mock_kms, b64_secret)
+        self.mock_kms.decrypt.assert_called_once_with(CiphertextBlob=self.secret)
+
+    def test_kms_decrypt_fails_without_b64_secret(self):
+        """Ensures that function fails when passed a non-base64 encoded secret"""
+        with self.assertRaises((SystemExit, TypeError)):
+            ef_password.kms_decrypt(self.mock_kms, self.secret)
+
+    def test_kms_decrypt_fails_client_error(self):
+        """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
+        self.mock_kms.decrypt.side_effect = self.client_error
+        with self.assertRaises((SystemExit, ClientError)):
+            ef_password.kms_decrypt(self.mock_kms, self.secret)

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import base64
+
 import unittest
+import base64
 
 from botocore.exceptions import ClientError
 from mock import Mock, patch
@@ -24,7 +25,7 @@ import context_paths
 ef_password = __import__("ef-password")
 
 
-class TestEFGenerate(unittest.TestCase):
+class TestEFPassword(unittest.TestCase):
 
     def setUp(self):
         self.service = "test-service"
@@ -79,3 +80,7 @@ class TestEFGenerate(unittest.TestCase):
         self.mock_kms.decrypt.side_effect = self.client_error
         with self.assertRaises((SystemExit, ClientError)):
             ef_password.kms_decrypt(self.mock_kms, self.secret)
+
+    @patch('sys.argv')
+    def test_ef_password_fails_non_int_length(self, patched_argv):
+        patched_argv.return_value = ['test', self.service, self.env]

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -155,7 +155,7 @@ class TestEFUtils(unittest.TestCase):
     mock_urllib2.return_value = mock_response
     with self.assertRaises(IOError) as exception:
       ef_utils.http_get_metadata("ami-id")
-    self.assertIn("Non-200 response", str(exception.exception.message))
+    self.assertIn("Non-200 response", exception.exception.message)
 
   @patch('ef_utils.gethostname')
   def test_whereami_local(self, mock_gethostname):

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -14,15 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import base64
 from StringIO import StringIO
 import unittest
 
+from botocore.exceptions import ClientError
 from mock import Mock, patch
 
 # For local application imports, context_paths must be first despite lexicon ordering
 import context_paths
 from ef_site_config import EFSiteConfig
 import ef_utils
+
 
 class TestEFUtils(unittest.TestCase):
   """
@@ -152,7 +155,7 @@ class TestEFUtils(unittest.TestCase):
     mock_urllib2.return_value = mock_response
     with self.assertRaises(IOError) as exception:
       ef_utils.http_get_metadata("ami-id")
-    self.assertIn("Non-200 response", exception.exception.message)
+    self.assertIn("Non-200 response", str(exception.exception.message))
 
   @patch('ef_utils.gethostname')
   def test_whereami_local(self, mock_gethostname):
@@ -711,5 +714,56 @@ class TestEFUtils(unittest.TestCase):
       ef_utils.global_env_valid(None)
     self.assertTrue("Invalid global env" in exception.exception.message)
 
+
+class TestEFUtilsKMS(unittest.TestCase):
+    """Test cases for functions using kms"""
+    def setUp(self):
+        self.service = "test-service"
+        self.env = "test"
+        self.secret = "secret"
+        self.error_response = {'Error': {'Code': 'FakeError', 'Message': 'Testing catch of all ClientErrors'}}
+        self.client_error = ClientError(self.error_response, "boto3")
+        self.mock_kms = Mock(name="mocked kms client")
+        self.bytes_return = "cipher_blob".encode()
+        self.mock_kms.encrypt.return_value = {"CiphertextBlob": self.bytes_return}
+        self.mock_kms.decrypt.return_value = {"Plaintext": self.bytes_return}
+
+    def test_kms_encrypt_call(self):
+        """Validates basic kms call parameters"""
+        ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+        self.mock_kms.encrypt.assert_called_once_with(
+            KeyId='alias/{}-{}'.format(self.env, self.service),
+            Plaintext=self.secret.encode()
+        )
+
+    def test_kms_encrypt_returns_b64(self):
+        """Validate that function returns a base64 encoded value"""
+        encrypted_secret = ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+        b64_return = base64.b64encode(self.bytes_return)
+        self.assertEqual(b64_return, encrypted_secret)
+
+    def test_kms_encrypt_fails_client_error(self):
+        """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
+        self.mock_kms.encrypt.side_effect = self.client_error
+        with self.assertRaises((SystemExit, ClientError)):
+            ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+
+    def test_kms_decrypt_call(self):
+        """Validates basic kms call parameters"""
+        b64_secret = base64.b64encode(self.secret)
+        ef_utils.kms_decrypt(self.mock_kms, b64_secret)
+        self.mock_kms.decrypt.assert_called_once_with(CiphertextBlob=self.secret)
+
+    def test_kms_decrypt_fails_without_b64_secret(self):
+        """Ensures that function fails when passed a non-base64 encoded secret"""
+        with self.assertRaises((SystemExit, TypeError)):
+            ef_utils.kms_decrypt(self.mock_kms, self.secret)
+
+    def test_kms_decrypt_fails_client_error(self):
+        """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
+        self.mock_kms.decrypt.side_effect = self.client_error
+        with self.assertRaises((SystemExit, ClientError)):
+            ef_utils.kms_decrypt(self.mock_kms, self.secret)
+
 if __name__ == '__main__':
-   unittest.main()
+    unittest.main()

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -716,54 +716,56 @@ class TestEFUtils(unittest.TestCase):
 
 
 class TestEFUtilsKMS(unittest.TestCase):
-    """Test cases for functions using kms"""
-    def setUp(self):
-        self.service = "test-service"
-        self.env = "test"
-        self.secret = "secret"
-        self.error_response = {'Error': {'Code': 'FakeError', 'Message': 'Testing catch of all ClientErrors'}}
-        self.client_error = ClientError(self.error_response, "boto3")
-        self.mock_kms = Mock(name="mocked kms client")
-        self.bytes_return = "cipher_blob".encode()
-        self.mock_kms.encrypt.return_value = {"CiphertextBlob": self.bytes_return}
-        self.mock_kms.decrypt.return_value = {"Plaintext": self.bytes_return}
+  """Test cases for functions using kms"""
 
-    def test_kms_encrypt_call(self):
-        """Validates basic kms call parameters"""
-        ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
-        self.mock_kms.encrypt.assert_called_once_with(
-            KeyId='alias/{}-{}'.format(self.env, self.service),
-            Plaintext=self.secret.encode()
-        )
+  def setUp(self):
+    self.service = "test-service"
+    self.env = "test"
+    self.secret = "secret"
+    self.error_response = {'Error': {'Code': 'FakeError', 'Message': 'Testing catch of all ClientErrors'}}
+    self.client_error = ClientError(self.error_response, "boto3")
+    self.mock_kms = Mock(name="mocked kms client")
+    self.bytes_return = "cipher_blob".encode()
+    self.mock_kms.encrypt.return_value = {"CiphertextBlob": self.bytes_return}
+    self.mock_kms.decrypt.return_value = {"Plaintext": self.bytes_return}
 
-    def test_kms_encrypt_returns_b64(self):
-        """Validate that function returns a base64 encoded value"""
-        encrypted_secret = ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
-        b64_return = base64.b64encode(self.bytes_return)
-        self.assertEqual(b64_return, encrypted_secret)
+  def test_kms_encrypt_call(self):
+    """Validates basic kms call parameters"""
+    ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+    self.mock_kms.encrypt.assert_called_once_with(
+      KeyId='alias/{}-{}'.format(self.env, self.service),
+      Plaintext=self.secret.encode()
+    )
 
-    def test_kms_encrypt_fails_client_error(self):
-        """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
-        self.mock_kms.encrypt.side_effect = self.client_error
-        with self.assertRaises(SystemExit):
-            ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+  def test_kms_encrypt_returns_b64(self):
+    """Validate that function returns a base64 encoded value"""
+    encrypted_secret = ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
+    b64_return = base64.b64encode(self.bytes_return)
+    self.assertEqual(b64_return, encrypted_secret)
 
-    def test_kms_decrypt_call(self):
-        """Validates basic kms call parameters"""
-        b64_secret = base64.b64encode(self.secret)
-        ef_utils.kms_decrypt(self.mock_kms, b64_secret)
-        self.mock_kms.decrypt.assert_called_once_with(CiphertextBlob=self.secret)
+  def test_kms_encrypt_fails_client_error(self):
+    """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
+    self.mock_kms.encrypt.side_effect = self.client_error
+    with self.assertRaises(SystemExit):
+      ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
 
-    def test_kms_decrypt_fails_without_b64_secret(self):
-        """Ensures that function fails when passed a non-base64 encoded secret"""
-        with self.assertRaises(SystemExit):
-            ef_utils.kms_decrypt(self.mock_kms, self.secret)
+  def test_kms_decrypt_call(self):
+    """Validates basic kms call parameters"""
+    b64_secret = base64.b64encode(self.secret)
+    ef_utils.kms_decrypt(self.mock_kms, b64_secret)
+    self.mock_kms.decrypt.assert_called_once_with(CiphertextBlob=self.secret)
 
-    def test_kms_decrypt_fails_client_error(self):
-        """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
-        self.mock_kms.decrypt.side_effect = self.client_error
-        with self.assertRaises(SystemExit):
-            ef_utils.kms_decrypt(self.mock_kms, self.secret)
+  def test_kms_decrypt_fails_without_b64_secret(self):
+    """Ensures that function fails when passed a non-base64 encoded secret"""
+    with self.assertRaises(SystemExit):
+      ef_utils.kms_decrypt(self.mock_kms, self.secret)
+
+  def test_kms_decrypt_fails_client_error(self):
+    """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
+    self.mock_kms.decrypt.side_effect = self.client_error
+    with self.assertRaises(SystemExit):
+      ef_utils.kms_decrypt(self.mock_kms, self.secret)
+
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -745,7 +745,7 @@ class TestEFUtilsKMS(unittest.TestCase):
     def test_kms_encrypt_fails_client_error(self):
         """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
         self.mock_kms.encrypt.side_effect = self.client_error
-        with self.assertRaises((SystemExit, ClientError)):
+        with self.assertRaises(SystemExit):
             ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)
 
     def test_kms_decrypt_call(self):
@@ -756,13 +756,13 @@ class TestEFUtilsKMS(unittest.TestCase):
 
     def test_kms_decrypt_fails_without_b64_secret(self):
         """Ensures that function fails when passed a non-base64 encoded secret"""
-        with self.assertRaises((SystemExit, TypeError)):
+        with self.assertRaises(SystemExit):
             ef_utils.kms_decrypt(self.mock_kms, self.secret)
 
     def test_kms_decrypt_fails_client_error(self):
         """Ensures that function fails a generic ClientError despite any special handling for specific error codes"""
         self.mock_kms.decrypt.side_effect = self.client_error
-        with self.assertRaises((SystemExit, ClientError)):
+        with self.assertRaises(SystemExit):
             ef_utils.kms_decrypt(self.mock_kms, self.secret)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Final PR for the secure credentials project. Adds the ef-password utility and test coverage. 
[CXOPS-3057](https://ellation.atlassian.net/browse/CXOPS-3057)
## Changelog
- ef-password util
- unit and integration tests for ef-password
- unit tests for kms functions recently added to ef_utils
- fixing small type error bug in ef_utils
## Testing
### Create ef-password binary with pants: 
```
○ → ./pants binary ef-open/src:
fatal: Not a git repository (or any of the parent directories): .git

16:41:28 00:00 [main]
               (To run a reporting server: ./pants server)
16:41:28 00:00   [setup]
16:41:28 00:00     [parse]fatal: Not a git repository (or any of the parent directories): .git

               Executing tasks in goals: bootstrap -> imports -> unpack-jars -> deferred-sources -> gen -> jvm-platform-validate -> resolve -> compile -> resources -> binary
16:41:28 00:00   [bootstrap]
16:41:28 00:00     [substitute-aliased-targets]
16:41:28 00:00     [jar-dependency-management]
16:41:28 00:00     [bootstrap-jvm-tools]
16:41:28 00:00     [provide-tools-jar]
16:41:28 00:00   [imports]
16:41:28 00:00     [ivy-imports]
16:41:28 00:00   [unpack-jars]
16:41:28 00:00     [unpack-jars]
16:41:28 00:00   [deferred-sources]
16:41:28 00:00     [deferred-sources]
16:41:28 00:00   [gen]
16:41:28 00:00     [thrift]
16:41:28 00:00     [protoc]
16:41:28 00:00     [antlr]
16:41:28 00:00     [ragel]
16:41:28 00:00     [jaxb]
16:41:28 00:00     [wire]
16:41:28 00:00   [jvm-platform-validate]
16:41:28 00:00     [jvm-platform-validate]
16:41:28 00:00   [resolve]
16:41:28 00:00     [ivy]
16:41:28 00:00   [compile]
16:41:28 00:00     [compile-jvm-prep-command]
16:41:28 00:00       [jvm_prep_command]
16:41:28 00:00     [scalafmt]
16:41:28 00:00     [compile-prep-command]
16:41:28 00:00     [compile]
16:41:28 00:00     [zinc]
16:41:28 00:00     [jvm-dep-check]
16:41:28 00:00   [resources]
16:41:28 00:00     [prepare]
16:41:28 00:00     [services]
16:41:28 00:00   [binary]
16:41:29 00:01     [binary-jvm-prep-command]
16:41:29 00:01       [jvm_prep_command]
16:41:29 00:01     [binary-prep-command]
16:41:29 00:01     [python-binary-create]
16:41:29 00:01       [cache]
                   No cached artifacts for 1 target.
                   Invalidated 1 target.
                   created pex copy dist/ef-cf.pex
                   created pex copy dist/ef-check-config.pex
                   created pex copy dist/ef-generate.pex
                   created pex copy dist/ef-instanceinit.pex
16:41:29 00:01       [chroot]
                   created pex copy dist/ef-password.pex
                   created pex copy dist/ef-resolve-config.pex
                   created pex copy dist/ef-version.pex
16:41:30 00:02     [jvm]
16:41:30 00:02     [dup]
               Waiting for background workers to finish.
16:41:31 00:03   [complete]
               SUCCESS
```

### Use ef-password to create a secret and encrypt it, then a second call to decrypt the previously provided output: 
```
py-2.7.13 dlutsch-mlt in ~/workspace/ellation_formation
± |CXOPS-3147 {3} U:2 ?:3 ✗| → ../dist/ef-password.pex test-instance-9 alpha0
Generated Secret: utVADkLNMaUgafzQVbApfxxA7ZigIk3m
Encrypted Secret: AQICAHhtVzP26DTUnoiteYoGNC1iwz0NI22Rfz1oBRWWoRre5AFtZSSmtPRmWFCAX/foDmNBAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM6QpqjabN6SJ8FVvzAgEQgDtFxlHWsmfENv8C8aHcnAkBEmofxWV9+7LMGTfKn8rjBdWEswFORCe7A1zMFrtSm4GLp9nSuKYke1CGTQ==

py-2.7.13 dlutsch-mlt in ~/workspace/ellation_formation
± |CXOPS-3147 {3} U:2 ?:3 ✗| → ../dist/ef-password.pex test-instance-9 alpha0 --decrypt AQICAHhtVzP26DTUnoiteYoGNC1iwz0NI22Rfz1oBRWWoRre5AFtZSSmtPRmWFCAX/foDmNBAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM6QpqjabN6SJ8FVvzAgEQgDtFxlHWsmfENv8C8aHcnAkBEmofxWV9+7LMGTfKn8rjBdWEswFORCe7A1zMFrtSm4GLp9nSuKYke1CGTQ==
utVADkLNMaUgafzQVbApfxxA7ZigIk3m
```

### Unit tests ef-password.py
```
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/dlutsch/.virtualenvs/etp/bin/python2.7
cachedir: ../.cache
rootdir: /Users/dlutsch/workspace/ef-open, inifile:
plugins: cov-2.5.1
collected 8 items

../tests/unit_tests/test_ef_password.py::TestEFPassword::test_args PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_invalid_env PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_length_too_small PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_nonint_length PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_generate_secret PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_main PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_decrypt PASSED
../tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_plaintext PASSED

---------- coverage: platform darwin, python 2.7.13-final-0 ----------
Name             Stmts   Miss  Cover
------------------------------------
ef-password.py      80      7    91%
```

### Unit tests ef_utils.py
_( 1 failure expected due to existing bug in code)_
```
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/dlutsch/.virtualenvs/etp/bin/python2.7
cachedir: ../.cache
rootdir: /Users/dlutsch/workspace/ef-open, inifile:
plugins: cov-2.5.1
collected 35 items

../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_no_profile PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_env_valid PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_env_valid_invalid_envs PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_None_message PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_empty_string PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_message PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_message_and_exception_data PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_account_alias PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_account_alias_invalid_env PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_env_short PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_env_short_invalid_envs PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context_ec2_invalid_environment_exception PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context_metadata_exception PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_global_env_valid PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_global_env_valid_non_scoped_envs PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_env PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_env_exception PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_role PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_role_exception PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_metadata_200_status_code PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_metadata_non_200_status_code PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_https_credentials FAILED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_incorrect_branch PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_incorrect_repo PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_ssh_credentials PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_local PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_unknown PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_call PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_client_error PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_without_b64_secret PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_fails_client_error PASSED
../tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_returns_b64 PASSED

---------- coverage: platform darwin, python 2.7.13-final-0 ----------
Name          Stmts   Miss  Cover
---------------------------------
ef_utils.py     152     22    86%
```