### PR TITLE
ef-instanceinit localdev

### DIFF
--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -54,6 +54,10 @@ class EFSiteConfig:
     "proto": 4
   }
 
+  # Env name for local development with vagrant, used for rendering config templates.
+  # Vagrantfile vm.hostname domain should match the rendered value.
+  VAGRANT_ENV = "local"
+
   # Bucket where late-bound service configs are found. See doc/name-patterns.md for S3 bucket naming conventions
   #   Bucket name should be in this form: <S3PREFIX>-global-configs
   #   Bucket does not have to exist yet (you will need the built tools to create it via CloudFormation)

--- a/src/ef-instanceinit.py
+++ b/src/ef-instanceinit.py
@@ -34,6 +34,7 @@ import boto3
 import boto3.utils
 import botocore.exceptions
 
+from ef_config import EFConfig
 from ef_instanceinit_config_reader import EFInstanceinitConfigReader
 from ef_utils import http_get_instance_role, http_get_metadata, whereami
 from ef_template_resolver import EFTemplateResolver
@@ -43,8 +44,9 @@ LOG_IDENT = "ef-instanceinit"
 VIRTUALBOX_CONFIG_ROOT = "/vagrant/configs"
 
 # globals
-RESOURCES = {} #boto resources (easier to use for some things)
+RESOURCES = {}  # boto resources (easier to use for some things)
 WHERE = None
+
 
 def log_info(message):
   """
@@ -55,6 +57,7 @@ def log_info(message):
   print(message)
   syslog(message)
 
+
 def critical(message):
   """
   Log critical error to log_info and console and exit with error status
@@ -62,6 +65,7 @@ def critical(message):
   log_info(message)
   closelog()
   sys.exit(1)
+
 
 def merge_files(service):
   """
@@ -87,7 +91,7 @@ def merge_files(service):
     if WHERE == "ec2":
       resolver = EFTemplateResolver()
     elif WHERE == "virtualbox-kvm":
-      resolver = EFTemplateResolver(env="localvm", service=service)
+      resolver = EFTemplateResolver(env=EFConfig.VAGRANT_ENV, service=service)
 
     log_info("checking: {}".format(config_reader.current_key))
 
@@ -96,8 +100,8 @@ def merge_files(service):
     if dest.has_key("environments"):
       if not resolver.resolved["ENV_SHORT"] in dest["environments"]:
         log_info("Environment: {} not enabled for {}".format(
-                  resolver.resolved["ENV_SHORT"], config_reader.current_key)
-                )
+          resolver.resolved["ENV_SHORT"], config_reader.current_key)
+        )
         continue
 
     # Process the template_body - apply context + parameters
@@ -177,6 +181,7 @@ def main():
 
   log_info("exit: success")
   closelog()
+
 
 if __name__ == "__main__":
   main()

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -28,7 +28,6 @@ class EFConfig(EFSiteConfig):
 
   # Default service registry file name
   DEFAULT_SERVICE_REGISTRY_FILE = "service_registry.json"
-  LOCAL_VM_LABEL = "localvm"
   PARAMETER_FILE_SUFFIX = ".parameters.json"
   POLICY_TEMPLATE_PATH_SUFFIX = "/policy_templates/"
   # the service group 'fixtures' always exists


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Change local dev env name from a hardcoded value ("localvm") to a variable stored in ef_site_config
[CXOPS-3246](https://ellation.atlassian.net/browse/CXOPS-3246)
## Changelog
- Update template resolver env param to use value from site config
- Include value in template site config file (getting-started/ef_site_config.py)
- Remove unused attribute from EFConfig class
- Small formatting updates to ef-instanceinit.py
## Linked PRs
https://github.com/crunchyroll/ellation_formation/pull/1436
## Testing
### ef-instanceinit renders the template inside the vagrant machine
```
[root@data-api vagrant]# python /usr/local/bin/ef-instanceinit
...
next item: '/vagrant/configs/data-api/templates/data-api.yaml'
checking: /vagrant/configs/data-api/templates/data-api.yaml
Loading parameters file: /vagrant/configs/data-api/templates/data-api.yaml
Resolving template
Loading template file: /vagrant/configs/data-api/templates/data-api.yaml
Loading parameters file: /vagrant/configs/data-api/templates/data-api.yaml
make directories: /srv/data-api 755
open: /srv/data-api/data-api.yaml,w+
write
close
chmod file to: 644
chown last directory in path to: wwwuser:wwwuser
chown file to: wwwuser:wwwuser
exit: success
```
### Config template output contains the env value pulled from ef_site_config
```
[root@data-api vagrant]# cat /srv/data-api/data-api.yaml
# port to listen on
# the current default deployment uses Elastic BeanStalk, which runs
# nginx on port 80 and forwards requests to localhost:8000, so this
# default listens on :8000
port: 8000

# file that stores dumps of requests that come to the /debug endpoint
debugOutput: /tmp/vrv-api-debug

# logging level
# valid values: debug, info, warn, error
logLevel: debug

cassandra:
    # Cassandra hosts to connect to
    # this config should only specify storage nodes, i.e. not include any analytics nodes
    hosts:
        - data-cassandra.cx-dev.com

    # number of seconds to wait between attempts to reconnect to Cassandra after it drops
    retryInterval: 5

    # username and password for Cassandra's own user access policy
    username: "cassandra"
    password: ****

newRelic:
    appName: "dev-data-api"
    license: ****

# where to forward events that come to the /event endpoint
# currently, this should point to an `eventagg` server,
# but this set of options should cease to exist prior to VRV launch
events:
    # `net` must be either "tcp" or "udp"
    net: udp

    # `host` must be in the form "host:port"
    host: data-aggregation.cx-dev.com:5000
```