### PR TITLE
Update ef-password to accommodate subservices

### DIFF
--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -400,7 +400,7 @@ def conditionally_create_kms_key(role_name, service_type):
   }'''
 
   if not kms_key:
-    print("Create KMS key: {}".format(role_name))
+    print("Create KMS key: {}".format(key_alias))
     if CONTEXT.commit:
       # Create KMS Master Key. Due to AWS eventual consistency a newly created IAM role may not be 
       # immediately visible to KMS. Retrying up to 5 times (25 seconds) to account for this behavior.

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -278,14 +278,17 @@ def kms_encrypt(kms_client, service, env, secret):
   Raises:
     SystemExit(1): If there is an error with the boto3 encryption call (ex. missing kms key)
   """
+  # Converting all periods to underscores because they are invalid in KMS alias names
+  key_alias = '{}-{}'.format(env, service.replace('.', '_'))
+
   try:
     response = kms_client.encrypt(
-      KeyId='alias/{}-{}'.format(env, service),
+      KeyId='alias/{}'.format(key_alias),
       Plaintext=secret.encode()
     )
   except ClientError as error:
     if error.response['Error']['Code'] == "NotFoundException":
-      fail("Key '{}-{}' not found. You may need to run ef-generate for this environment.".format(env, service), error)
+      fail("Key '{}' not found. You may need to run ef-generate for this environment.".format(key_alias), error)
     else:
       fail("boto3 exception occurred while performing kms encrypt operation.", error)
   encrypted_secret = base64.b64encode(response['CiphertextBlob'])

--- a/tests/unit_tests/test_ef_generate.py
+++ b/tests/unit_tests/test_ef_generate.py
@@ -21,87 +21,101 @@ from mock import Mock, patch
 
 import context_paths
 from ef_context import EFContext
+
 ef_generate = __import__("ef-generate")
 
 
 class TestEFGenerate(unittest.TestCase):
+  def setUp(self):
+    self.service_name = "proto0-test-service"
+    self.service_type = "http_service"
+    self.malformed_policy_response = {'Error': {'Code': 'MalformedPolicyDocumentException',
+                                                'Message': 'Error creating key'}}
+    self.malformed_policy_client_error = ClientError(self.malformed_policy_response, "create_key")
+    self.not_found_response = {'Error': {'Code': 'NotFoundException', 'Message': 'Error describing key'}}
+    self.not_found_client_error = ClientError(self.not_found_response, "describe_key")
+    self.mock_kms = Mock(name="mocked kms client")
+    self.mock_kms.create_key.return_value = {"KeyMetadata": {"KeyId": "1234"}}
+    self.mock_kms.describe_key.side_effect = self.not_found_client_error
+    ef_generate.CONTEXT = EFContext()
+    ef_generate.CONTEXT.commit = True
+    ef_generate.CONTEXT.account_id = "1234"
+    ef_generate.CLIENTS = {"kms": self.mock_kms}
 
-    def setUp(self):
-        self.service_name = "proto0-test-service"
-        self.service_type = "http_service"
-        self.malformed_policy_response = {'Error': {'Code': 'MalformedPolicyDocumentException',
-                                                    'Message': 'Error creating key'}}
-        self.malformed_policy_client_error = ClientError(self.malformed_policy_response, "create_key")
-        self.not_found_response = {'Error': {'Code': 'NotFoundException', 'Message': 'Error describing key'}}
-        self.not_found_client_error = ClientError(self.not_found_response, "describe_key")
-        self.mock_kms = Mock(name="mocked kms client")
-        self.mock_kms.create_key.return_value = {"KeyMetadata": {"KeyId": "1234"}}
-        self.mock_kms.describe_key.side_effect = self.not_found_client_error
-        ef_generate.CONTEXT = EFContext()
-        ef_generate.CONTEXT.commit = True
-        ef_generate.CONTEXT.account_id = "1234"
-        ef_generate.CLIENTS = {"kms": self.mock_kms}
+  def test_create_kms_key(self):
+    """
+    Check that when an existing key is not found that the create key/alias methods are called with the correct
+    parameters.
+    """
+    ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
 
-    def test_create_kms_key(self):
-        """
-        Check that when an existing key is not found that the create key/alias methods are called with the correct
-        parameters.
-        """
-        ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
+    self.mock_kms.create_key.assert_called()
+    self.mock_kms.create_alias.assert_called_with(
+      AliasName='alias/{}'.format(self.service_name),
+      TargetKeyId='1234'
+    )
 
-        self.mock_kms.create_key.assert_called()
-        self.mock_kms.create_alias.assert_called_with(
-            AliasName='alias/{}'.format(self.service_name),
-            TargetKeyId='1234'
-        )
+  def test_create_kms_key_subservice(self):
+    """
+    Verify that subservices (formatted as service-name.subservice in the service registry) are created using an
+    underscore in place of a period for the key alias.
+    """
+    subservice = self.service_name + ".subservice"
+    ef_generate.conditionally_create_kms_key(subservice, self.service_type)
 
-    def test_kms_key_already_exists(self):
-        """
-        Check that when an existing key is found the create key/alias methods are not called.
-        """
-        self.mock_kms.describe_key.side_effect = None
-        self.mock_kms.describe_key.return_value = Mock()
-        ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
+    self.mock_kms.create_key.assert_called()
+    self.mock_kms.create_alias.assert_called_with(
+      AliasName='alias/{}'.format(self.service_name + "_subservice"),
+      TargetKeyId='1234'
+    )
 
-        self.mock_kms.create_key.assert_not_called()
-        self.mock_kms.create_alias.assert_not_called()
+  def test_kms_key_already_exists(self):
+    """
+    Check that when an existing key is found the create key/alias methods are not called.
+    """
+    self.mock_kms.describe_key.side_effect = None
+    self.mock_kms.describe_key.return_value = Mock()
+    ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
 
-    def test_not_kms_service_type(self):
-        """
-        Validates that a key/alias is not created for unsupported service types
-        """
-        self.service_type = "invalid_service"
-        ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
+    self.mock_kms.create_key.assert_not_called()
+    self.mock_kms.create_alias.assert_not_called()
 
-        self.mock_kms.describe_key.assert_not_called()
-        self.mock_kms.create_key.assert_not_called()
-        self.mock_kms.create_alias.assert_not_called()
+  def test_not_kms_service_type(self):
+    """
+    Validates that a key/alias is not created for unsupported service types
+    """
+    self.service_type = "invalid_service"
+    ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
 
-    @patch('time.sleep', return_value=None)
-    def test_kms_eventual_consistency_resilience(self, patched_time_sleep):
-        """
-        Validate that conditionally_create_kms_key will account for aws eventual consistency when attempting to
-        reference a newly created ec2 role. Providing three exceptions and then success.
-        """
-        self.mock_kms.create_key.side_effect = [
-            self.malformed_policy_client_error,
-            self.malformed_policy_client_error,
-            self.malformed_policy_client_error,
-            {"KeyMetadata": {"KeyId": "1234"}}
-        ]
-        ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
+    self.mock_kms.describe_key.assert_not_called()
+    self.mock_kms.create_key.assert_not_called()
+    self.mock_kms.create_alias.assert_not_called()
 
-        self.mock_kms.create_alias.assert_called_with(
-            AliasName='alias/{}'.format(self.service_name),
-            TargetKeyId='1234'
-        )
+  @patch('time.sleep', return_value=None)
+  def test_kms_eventual_consistency_resilience(self, patched_time_sleep):
+    """
+    Validate that conditionally_create_kms_key will account for aws eventual consistency when attempting to
+    reference a newly created ec2 role. Providing three exceptions and then success.
+    """
+    self.mock_kms.create_key.side_effect = [
+      self.malformed_policy_client_error,
+      self.malformed_policy_client_error,
+      self.malformed_policy_client_error,
+      {"KeyMetadata": {"KeyId": "1234"}}
+    ]
+    ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
 
-    @patch('time.sleep', return_value=None)
-    def test_kms_create_key_eventual_consistency_failure(self, patched_time_sleep):
-        """
-        Validate that create_key call fails after 5 MalformedPolicyDocumentException's.
-        """
-        self.mock_kms.create_key.side_effect = self.malformed_policy_client_error
-        with self.assertRaises(SystemExit) as error:
-            ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
-        self.assertEquals(error.exception.code, 1)
+    self.mock_kms.create_alias.assert_called_with(
+      AliasName='alias/{}'.format(self.service_name),
+      TargetKeyId='1234'
+    )
+
+  @patch('time.sleep', return_value=None)
+  def test_kms_create_key_eventual_consistency_failure(self, patched_time_sleep):
+    """
+    Validate that create_key call fails after 5 MalformedPolicyDocumentException's.
+    """
+    self.mock_kms.create_key.side_effect = self.malformed_policy_client_error
+    with self.assertRaises(SystemExit) as error:
+      ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
+    self.assertEquals(error.exception.code, 1)

--- a/tests/unit_tests/test_ef_generate.py
+++ b/tests/unit_tests/test_ef_generate.py
@@ -21,7 +21,6 @@ from mock import Mock, patch
 
 import context_paths
 from ef_context import EFContext
-
 ef_generate = __import__("ef-generate")
 
 

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -28,7 +28,7 @@ ef_password = __import__("ef-password")
 class TestEFPassword(unittest.TestCase):
   def setUp(self):
     self.service = "test-service"
-    self.env = "test"
+    self.env = "internal"
     self.secret = "secret"
     self.error_response = {'Error': {'Code': 'FakeError', 'Message': 'Testing catch of all ClientErrors'}}
     self.client_error = ClientError(self.error_response, "boto3")

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -737,6 +737,16 @@ class TestEFUtilsKMS(unittest.TestCase):
       Plaintext=self.secret.encode()
     )
 
+  def test_kms_encrypt_call_subservice(self):
+    """Validate KMS encryption call on a subservice, where periods should be converted to underscores due to
+    alias name restrictions"""
+    subservice = self.service + ".subservice"
+    ef_utils.kms_encrypt(self.mock_kms, subservice, self.env, self.secret)
+    self.mock_kms.encrypt.assert_called_once_with(
+      KeyId='alias/{}-{}'.format(self.env, self.service + "_subservice"),
+      Plaintext=self.secret.encode()
+    )
+
   def test_kms_encrypt_returns_b64(self):
     """Validate that function returns a base64 encoded value"""
     encrypted_secret = ef_utils.kms_encrypt(self.mock_kms, self.service, self.env, self.secret)


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
KMS does not allow periods in key alias names which breaks when generating keys for subservices ([kms alias doc](http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html)). Updating code to convert all periods to underscores for key aliases. 
[CXOPS-3291](https://ellation.atlassian.net/browse/CXOPS-3291)
## Changelog
- ef-generate to create aliases with an underscore in place of any periods
- ef_utils.kms_encrypt() will try to use an alias with an underscore rather than period when called
- add tests for the above
- env name "test" is no longer valid, updated test_ef_password accordingly
- convert test_ef_generate to two spaces 
## Testing
### Unit tests
```
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/dlutsch/.virtualenvs/etp/bin/python2.7
cachedir: .cache
rootdir: /Users/dlutsch/workspace/ef-open, inifile:
plugins: cov-2.5.1
collected 36 items

tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_call PASSED
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_client_error PASSED
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_without_b64_secret PASSED
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call PASSED
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call_subservice PASSED
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_fails_client_error PASSED
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_returns_b64 PASSED

---------- coverage: platform darwin, python 2.7.13-final-0 ----------
Name              Stmts   Miss  Cover
-------------------------------------
src/ef_utils.py     153    104    32%
```
```
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/dlutsch/.virtualenvs/etp/bin/python2.7
cachedir: .cache
rootdir: /Users/dlutsch/workspace/ef-open, inifile:
plugins: cov-2.5.1
collected 8 items

tests/unit_tests/test_ef_password.py::TestEFPassword::test_args PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_invalid_env PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_length_too_small PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_nonint_length PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_generate_secret PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_decrypt PASSED
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_plaintext PASSED

---------- coverage: platform darwin, python 2.7.13-final-0 ----------
Name                 Stmts   Miss  Cover
----------------------------------------
src/ef-password.py      79      6    92%
```
### Test subservice in alpha0
#### Used updated ef-generate with a test service registry that has the service "test-instance-9.subservice"

Alias is created with the correct name: `alpha0-test-instance-9_subservice`
Key Policy allows decrypt to the correct subservice role name (period rather than underscore):
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Enable IAM User Permissions",
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::490645551402:root"
      },
      "Action": "kms:*",
      "Resource": "*"
    },
    {
      "Sid": "Allow Service Role Decrypt Privileges",
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::490645551402:role/alpha0-test-instance-9.subservice"
      },
      "Action": "kms:Decrypt",
      "Resource": "*"
    }
  ]
}
```