### PR TITLE
Accept empty strings as parameter values

### DIFF
--- a/src/ef_template_resolver.py
+++ b/src/ef_template_resolver.py
@@ -428,7 +428,7 @@ class EFTemplateResolver(object):
           if not resolved_symbol:
             resolved_symbol = self.search_parameters(symbol)
         # if symbol was resolved, replace it everywhere
-        if resolved_symbol:
+        if resolved_symbol is not None:
           self.resolved[symbol] = resolved_symbol
           if isinstance(resolved_symbol, list):
             self.template = self.template.replace("{{"+symbol+"}}", "\n".join(self.resolved[symbol]))


### PR DESCRIPTION
## Ready State.
**Not Ready**
Need to clarify what to do in case of empty lists as values.
## Synopsis
This PR allows setting params with empty strings as.
A few examples:
1. param is missing - we should throw an error
2. param exists, value is not set - we should throw an error
3. param exists, value is empty string "" -correct value
4. param exists, value is [] (empty list) - UNCLEAR
## Changelog
Allow empty strings as values.
## Testing
> Include instructions for testing this PR.  The format of this should be numbered bullets (use `1.` for each bullet
> in your markdown) with sub-bullets for assertions.  Bug fixes should 
> contain instructions for confirming the bug before confirming the fix.  Please include screenshots and explanations 
> of jargon where appropriate. 

- Build config template and param set with empty strings as param values (example provided lower).
- run `ef-resolve-config` on the template.
*Expected*: build a template with all values in place.
*Actual result*: fails with `Couldn't resolve all symbols` error, detailing symbols with empty string values.
Example configs:
```
# run while in the ellation_formation folder
cat > ./configs/all/templates/null-testing.template << EOF
{{empty_str}} is what an empty string looks like
{{value}} just sits here

{{jokes}}
{{bad_jokes}}
EOF

cat > ./configs/all/parameters/null-testing.template.parameters.json << EOF
{
  "dest": {
    "path": "/srv/playheads-external/config.yaml",
    "dir_perm": "755",
    "file_perm": "644",
    "user_group": "wwwuser:wwwuser"
  },
  "params": {
      "default": {
          "empty_str": "",
          "value": "The cat",
          "jokes": [
                "There's this joke I know,",
                "not a good story,",
                "but it's funny, I promise"
          ],
          "bad_jokes": []
      }
  }
}
EOF

ef-resolve-config alpha0 ./configs/all/templates/null-testing.template
```