### PR TITLE
Allow any kind of newrelic alerts

### DIFF
--- a/plugins_available/newrelic/README.md
+++ b/plugins_available/newrelic/README.md
@@ -33,3 +33,15 @@ entry, then create a key for the alert condition you are attempting to modify. T
   }
 }
 ```
+
+### Quick steps to adding new alert conditions to config.py
+1. Create an alert condition in the newrelic ui
+2. browse to the alert metric (manage button from the alert policy view)
+3. Copy the alert condition id from the url bar. In the example below, the id is "678910"
+	For example: https://infrastructure.newrelic.com/accounts/1234567/settings/alerts/678910
+4. Retrieve the condition object from the newrelic api:
+	curl -sX GET --header "X-Api-Key: API_KEY"  "https://infra-api.newrelic.com/v2/alerts/conditions/565433" | jq .data
+5. add the cleaned up json condition object to alert_conditions in the config.py file. the key is the name of the alert condition, and the value should be the condition object. make sure the key and the objects "name" value match. 
+6. delete the following keys from the condition object: "id", "created_at_epoch_millis", "updated_at_epoch_millis"
+7. update dynamic values to variables. The variables available are {{ENV}}, {{SERVICE}}, and {{POLICY_ID}}. One value that will certainly need to be changed is "policy_id". Typically filter values will use these variables as well. 
+8. Change the "enabled" value to be a python boolean; True or False (note capitalization)

--- a/plugins_available/newrelic/README.md
+++ b/plugins_available/newrelic/README.md
@@ -3,39 +3,33 @@ Automate the creation of baseline NewRelic ec2 infrastructure alerts applicable 
 service_registry
 
 ### Expected pattern
-This plugin will create _service_ and _service-warn_ alert policies in NewRelic for all applications in the
-service_registry. These alert policies will contain infrastructure alert conditions which target ec2 instances created 
-and tagged by ef-cf. 
-
-### Api Token
-The encrypted_token config value should be a NewRelic admin token encrypted by KMS. Any AWS accounts with environments
-in  config.alert_environments will need decrypt privileges to this key. 
-
-### Current restrictions
-Currently only infrastructure alerts are supported by this plugin (ie. metrics viewable in 
-https://infrastructure.newrelic.com). If additional alert condition types are required (apdex, synthetic transactions, 
-etc.) this functionality can be extended. 
+This plugin will create alert policy for all application services in the service registry. The name of each policy will
+be in the format of env-service and will be created for all environments in the config.env_notification_map
 
 ### Service registry
 config.conditions defines the alert conditions as well as the default threshold levels. However, these default values 
 can be overwritten at the service level within the service_registry. To do so, create an "alerts" key in the service's
-entry, then set new values for {{alert}}_warning and/or {{alert}}_critical. The alert names can be found in the "sr_name"
-key in config.conditions. 
+entry, then create a key for the alert condition you are attempting to modify. Then enter the condition key + new value.
 
 ##### Example service overwriting the cpu default thresholds:
 ```
 "myservice": {
-      "type": "http_service",
-      "description": "Example service",
-      "repository": "github.com/org/myservice",
-      "jira_project": "example",
-      "chef_role": "example",
-      "environments": ["prod", "staging", "proto", "alpha"],
-      "policies": ["global_buckets_ro", "instance_introspection"],
-      "alerts": {
-        "cpu_warning": 70,
-        "cpu_critical": 75
+  "type": "http_service",
+  "description": "Example service",
+  "repository": "github.com/org/myservice",
+  "jira_project": "example",
+  "chef_role": "example",
+  "environments": ["prod", "staging", "proto", "alpha"],
+  "policies": ["global_buckets_ro", "instance_introspection"],
+  "alerts": {
+    "replica_lag": {
+      "critical_threshold": {
+        "value": 40
       }
+    },
+    "cpu_percent": {
+        "enabled": false
     }
   }
+}
 ```

--- a/plugins_available/newrelic/README.md
+++ b/plugins_available/newrelic/README.md
@@ -39,8 +39,8 @@ entry, then create a key for the alert condition you are attempting to modify. T
 2. browse to the alert metric (manage button from the alert policy view)
 3. Copy the alert condition id from the url bar. In the example below, the id is "678910"
 	For example: https://infrastructure.newrelic.com/accounts/1234567/settings/alerts/678910
-4. Retrieve the condition object from the newrelic api:
-	curl -sX GET --header "X-Api-Key: API_KEY"  "https://infra-api.newrelic.com/v2/alerts/conditions/565433" | jq .data
+4. Retrieve the condition object from the newrelic api:<br>
+	`curl -sX GET --header "X-Api-Key: API_KEY"  "https://infra-api.newrelic.com/v2/alerts/conditions/565433" | jq .data`
 5. add the cleaned up json condition object to alert_conditions in the config.py file. the key is the name of the alert condition, and the value should be the condition object. make sure the key and the objects "name" value match. 
 6. delete the following keys from the condition object: "id", "created_at_epoch_millis", "updated_at_epoch_millis"
 7. update dynamic values to variables. The variables available are {{ENV}}, {{SERVICE}}, and {{POLICY_ID}}. One value that will certainly need to be changed is "policy_id". Typically filter values will use these variables as well. 

--- a/plugins_available/newrelic/executor.py
+++ b/plugins_available/newrelic/executor.py
@@ -17,12 +17,8 @@ class NewRelicAlerts(object):
 
   def __init__(self):
     # load config settings
-    self.alert_environments = config.alert_environments
-    self.critical_alert_environments = config.critical_alert_environments
     self.conditions = config.alert_conditions
-    self.encrypted_token = config.encrypted_token
-    self.critical_channels = config.critical_channels
-    self.warning_channels = config.warning_channels
+    self.admin_token = config.admin_token
     self.all_notification_channels = config.env_notification_map
 
   @classmethod
@@ -47,8 +43,10 @@ class NewRelicAlerts(object):
 
   def run(self):
     if self.context.env in self.all_notification_channels.keys():
-      admin_token = kms_decrypt(self.clients['kms'], self.encrypted_token)
-      newrelic = NewRelic(admin_token)
+      if config.token_kms_encrypted:
+        self.admin_token = kms_decrypt(self.clients['kms'], self.admin_token)
+
+      newrelic = NewRelic(self.admin_token)
 
       for service in self.context.service_registry.iter_services(service_group="application_services"):
         service_name = service[0]

--- a/plugins_available/newrelic/interface.py
+++ b/plugins_available/newrelic/interface.py
@@ -6,7 +6,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-class AlertPolicy:
+class AlertPolicy(object):
 
   def __init__(self, env, service):
     self._env = env
@@ -27,12 +27,10 @@ class AlertPolicy:
   @id.setter
   def id(self, value):
     try:
-      value = int(value)
+      self._id = int(value)
+      self.set_symbols()
     except ValueError:
       logger.error("Invalid value '{}' for policy id.".format(value))
-
-    self._id = value
-    self.set_symbols()
 
   @property
   def env(self):
@@ -71,7 +69,7 @@ class AlertPolicy:
     }
 
 
-class NewRelic:
+class NewRelic(object):
 
   def __init__(self, admin_token):
     self.admin_token = admin_token
@@ -141,6 +139,7 @@ class NewRelic:
       headers=self.auth_header,
       data=json.dumps({ "data": condition })
     )
+    print(add_condition.text)
     add_condition.raise_for_status()
     return add_condition.json()['data']['id']
 

--- a/plugins_available/newrelic/interface.py
+++ b/plugins_available/newrelic/interface.py
@@ -133,13 +133,11 @@ class NewRelic(object):
     return
 
   def create_alert_cond(self, condition):
-    print(json.dumps({ "data": condition }))
     add_condition = requests.post(
       url='https://infra-api.newrelic.com/v2/alerts/conditions',
       headers=self.auth_header,
       data=json.dumps({ "data": condition })
     )
-    print(add_condition.text)
     add_condition.raise_for_status()
     return add_condition.json()['data']['id']
 


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Previously the automated newrelic alerts were limited to ec2 instance metrics. This opens it up to work with any kind of metrics/condition. I've added several newrelic metrics to our config in ellation_formation (https://github.com/crunchyroll/ellation_formation/pull/1635)
[OPS-7814](https://ellation.atlassian.net/browse/OPS-7814)
## Testing
```
/Users/dlutsch/.virtualenvs/etp/bin/python /Users/dlutsch/workspace/ef-open/src/ef-generate.py staging --devel --commit
Not refreshing repo because --devel was set or running on Jenkins
env: staging
env_full: staging
env_short: staging
aws account profile: ellationeng
aws account number: 366843697376
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): kms.us-west-2.amazonaws.com
INFO:plugins.newrelic.executor:create condition rds_cpu_percent for policy staging-sv2-ingest
INFO:plugins.newrelic.executor:create condition rds_cpu_percent for policy staging-talkbox
INFO:plugins.newrelic.executor:create condition rds_cpu_percent for policy staging-sv2-api
Exit: success

Process finished with exit code 0
```
