### PR TITLE
Cf polling

### DIFF
--- a/getting-started/ef_site_config.py
+++ b/getting-started/ef_site_config.py
@@ -74,6 +74,10 @@ class EFSiteConfig:
     "platform_services"
   }
 
+  ## ef-cf settings ##
+  #   polling period for cloudformation stack status
+  EF_CF_POLL_PERIOD = 10
+
   ## Version-management settings ##
   #   is --noprecheck allowed with ef-version --set and --rollback?
   ALLOW_EF_VERSION_SKIP_PRECHECK = True

--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -274,7 +274,8 @@ def main():
           if re.match(r".*_COMPLETE(?!.)", stack_status) is not None:
             break
           elif re.match(r".*_FAILED(?!.)", stack_status) is not None:
-            break
+            print("Stack failed with status: {}".format(stack_status))
+            sys.exit(1)
           elif re.match(r".*_IN_PROGRESS(?!.)", stack_status) is not None:
             time.sleep(EFConfig.EF_CF_POLL_PERIOD)
     run_plugins(context, clients)


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Support polling of the cloudformation stack status in ef-cf. When enabled, ef-cf will block until stack create/update completion or failure. 

## Changelog
- add polling period to example ef_site_config
- add poll argument and support in context

## Linked PRs
[ellation-formation PR 1720](https://github.com/crunchyroll/ellation_formation/pull/1720)

## Testing
1. rebuild ef-cf
1. Set a new ami-id using the test-instance
  * `$ ef-version test-instance ami-id [ENV] --history text --limit 5`
  * `$  ef-version test-instance ami-id [ENV] --set [AMI-ID] --commit --devel`
1. Run ef-cf
  * `$ ef-cf cloudformation/services/templates/test-instance.json proto3 --devel --commit --poll --verbose`
  * Assert ef-cf reports stack status and finishes on completion of stack update
