### PR TITLE
change output to be more copy/paste friendly

### DIFF
--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -125,7 +125,7 @@ def main():
     password = generate_secret(context.length)
     print("Generated Secret: {}".format(password))
   encrypted_password = ef_utils.kms_encrypt(clients['kms'], context.service, context.env, password)
-  print("Encrypted Secret: {}".format(encrypted_password))
+  print("{{aws:kms:decrypt,%s}}" % encrypted_password)
   return
 
 


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Per conversation with Jerry, makes ef-password's output be more conducive for quick copy/paste
## Changelog
Changes output to include the lookups for ef template resolver
## Testing
```
○ → ef-password ece proto0
Generated Secret: kJ4brswtzArzcP9HEzk6XtwACtyZNdcr
{{aws:kms:decrypt,AQICAHistorhvkDyjb0bA1VwGEICk1xFQutt+BaEK+dPBnYxUAGy8WBRoqaNoFOGNG4WTuoLAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMm31NUisq6Vn+ylkSAgEQgDsqtOYHqE4Gm9Xgy17gmNAZotn0/6930zcB1kTe8STlov37uWXCtMwWmc6YjGJ99i3th9enqHY0Hl3lnw==}}
```
