### PR TITLE
Add Network ACL ID Lookup

### DIFF
--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -78,7 +78,7 @@ Example:<br>
 ```{{aws:acm:certificate-arn,us-west-2/mydomain.com}}```<br>
 returns:<br>
 ```arn:aws:acm:us-west-2:0123456789012:certificate/abcdef01-0123-abcd-0123-01234567890a```
- 
+
 #### {{aws:cloudfront:domain-name,\<cname>}}
 Returns: Domain name of the CloudFront distribution that hosts a given CNAME<br>
 Needs: Any domain name that's a CNAME on the desired CLoudFront distribution<br>
@@ -140,6 +140,16 @@ Example - interface '1' in subnet 'a' in env 'proto3' for the 'myservice' servic
 ```{{aws:ec2:eni/eni-id,eni-proto3-myservice-1a}}```<br>
 returns:<br>
 ```eni-31ca3f1a```
+
+#### {{aws:ec2:network/network-acl-id,\<network_acl_friendly_name>}}
+Returns: Network ACL ID<br>
+Needs: Network ACL's friendly name<br>
+Example:<br>
+```{{aws:ec2:network/network-acl-id,acl-{{ENV}}-<subnet_name>}}```<br>
+which is looked up in 'proto3' as:<br>
+```{{aws:ec2:network/network-acl-id,acl-proto3-subnetA}}```<br>
+returns:<br>
+```acl-be2d211a```<br>
 
 #### {{aws:ec2:route-table/main-route-table-id,\<vpc_name>}}
 Returns: Route table ID<br>

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -161,6 +161,23 @@ class EFAwsResolver(object):
     else:
       return default
 
+  def ec2_network_network_acl_id(self, lookup, default=None):
+    """
+    Args:
+      lookup: the friendly name of the network ACL we are looking up
+      default: the optional value to return if lookup failed; returns None if not set
+    Returns:
+      the ID of the network ACL, or None if no match found
+    """
+    network_acl_id = EFAwsResolver.__CLIENTS["ec2"].describe_network_acls(Filters=[{
+      'Name': 'tag:Name',
+      'Values': [lookup]
+    }])
+    if len(network_acl_id["NetworkAcls"]) > 0:
+      return network_acl_id["NetworkAcls"][0]["NetworkAclId"]
+    else:
+      return default
+
   def ec2_security_group_security_group_id(self, lookup, default=None):
     """
     Args:

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -82,12 +82,12 @@ class EFAwsResolver(object):
     for cert_handle in response["CertificateSummaryList"]:
       if cert_handle["DomainName"] == domain_name:
         cert = acm_client.describe_certificate(CertificateArn=cert_handle["CertificateArn"])["Certificate"]
+        # Patch up cert if there is no IssuedAt (i.e. cert was not issued by Amazon)
+        if not cert.has_key("IssuedAt"):
+          cert[u"IssuedAt"] = datetime.datetime(1970, 1, 1, 0, 0)
         if best_match_cert is None:
           best_match_cert = cert
-          # Patch up cert if there is no IssuedAt (i.e. cert was not issued by Amazon)
-          if not best_match_cert.has_key("IssuedAt"):
-            best_match_cert[u"IssuedAt"] = datetime.datetime(1970, 1, 1, 0, 0)
-        elif cert.has_key("IssuedAt") and cert["IssuedAt"] > best_match_cert["IssuedAt"]:
+        elif cert["IssuedAt"] > best_match_cert["IssuedAt"]:
           best_match_cert = cert
     if best_match_cert is not None:
       return best_match_cert["CertificateArn"]

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -354,7 +354,7 @@ class EFAwsResolver(object):
           return hosted_zone["Id"].split("/")[2]
       if hosted_zones["IsTruncated"]:
         hosted_zones = EFAwsResolver.__CLIENTS["route53"].list_hosted_zones_by_name(
-          MaxItems=list_limit, Marker=hosted_zones["NextMarker"])
+          DNSName=hosted_zones["NextDNSName"], HostedZoneId=hosted_zones["NextHostedZoneId"], MaxItems=list_limit)
       else:
         return default
 
@@ -380,7 +380,7 @@ class EFAwsResolver(object):
           return hosted_zone["Id"].split("/")[2]
       if hosted_zones["IsTruncated"]:
         hosted_zones = EFAwsResolver.__CLIENTS["route53"].list_hosted_zones_by_name(
-          MaxItems=list_limit, Marker=hosted_zones["NextMarker"])
+          DNSName=hosted_zones["NextDNSName"], HostedZoneId=hosted_zones["NextHostedZoneId"], MaxItems=list_limit)
       else:
         return default
 
@@ -506,8 +506,8 @@ class EFAwsResolver(object):
       return self.ec2_elasticip_elasticip_ipaddress(*kv[1:])
     elif kv[0] == "ec2:eni/eni-id":
       return self.ec2_eni_eni_id(*kv[1:])
-    elif kv[0] == "kms:decrypt":
-      return self.kms_decrypt_value(*kv[1:])
+    elif kv[0] == "ec2:network/network-acl-id":
+      return self.ec2_network_network_acl_id(*kv[1:])
     elif kv[0] == "ec2:route-table/main-route-table-id":
       return self.ec2_route_table_main_route_table_id(*kv[1:])
     elif kv[0] == "ec2:security-group/security-group-id":

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -490,7 +490,7 @@ class EFAwsResolver(object):
   def lookup(self, token):
     try:
       kv = token.split(",")
-    except ValueError:
+    except (ValueError, AttributeError):
       return None
     if kv[0] == "acm:certificate-arn":
       return self.acm_certificate_arn(*kv[1:])
@@ -522,6 +522,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_subnets(*kv[1:])
     elif kv[0] == "ec2:vpc/vpc-id":
       return self.ec2_vpc_vpc_id(*kv[1:])
+    elif kv[0] == "kms:decrypt":
+      return self.kms_decrypt_value(*kv[1:])
     elif kv[0] == "route53:private-hosted-zone-id":
       return self.route53_private_hosted_zone_id(*kv[1:])
     elif kv[0] == "route53:public-hosted-zone-id":


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Create a network acl ID lookup for template resolution
[OPS-8526](https://ellation.atlassian.net/browse/OPS-8526)

## Changelog
- update docs with network acl id symbol lookup
- create tests and fix broken tests
- create network acl lookup
- fix logic to add issued date to certs
- return none on lookup attribute errors
- update truncation handling logic

## Testing
============================= test session starts ==============================
platform darwin -- Python 2.7.10, pytest-3.2.2, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python
cachedir: Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/.cache
rootdir: /Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests, inifile:
plugins: cov-2.5.1
collecting ... collected 53 items
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_bad_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_multiple_matching_certificates PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_old_matching_certificate_has_no_issued_date PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_target_certificate_has_no_issued_date PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_id_bad_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_ipaddress PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_ipaddress_bad_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_eni_eni_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_eni_eni_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_network_network_acl_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_network_network_acl_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_route_table_main_route_table_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_route_table_main_route_table_id_no_single_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_security_group_security_group_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_security_group_security_group_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones_no_vpc_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_cidrblock PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_cidrblock_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_subnets PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_subnets_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_vpc_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_vpc_id_none PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_lookup_invalid_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_malformed_domain_name PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_malformed_domain_name PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id_more_rules_than_limit PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id_more_web_acls_than_limit PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id_no_match PASSED
 generated xml file: /var/folders/_7/5rwz5y3n2g7dl_m9gf2kdjyx8wq3lw/T/results4229vZI1jLJpzDN6.xml 
========================== 53 passed in 0.33 seconds ===========================
