### PR TITLE
Adding initial region support for ef-open

### DIFF
--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -190,6 +190,7 @@ def main():
     if profile:
       print("profile: {}".format(profile))
     print("whereami: {}".format(context.whereami))
+    print("region: {}".format(context.region))
     print("service type: {}".format(context.service_registry.service_record(service_name)["type"]))
 
   template = resolve_template(

--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -470,6 +470,7 @@ def main():
   print("env: {}".format(CONTEXT.env))
   print("env_full: {}".format(CONTEXT.env_full))
   print("env_short: {}".format(CONTEXT.env_short))
+  print("region: {}".format(CONTEXT.region))
   print("aws account profile: {}".format(CONTEXT.account_alias))
   print("aws account number: {}".format(CONTEXT.account_id))
 

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -89,6 +89,8 @@ def handle_args_and_set_context(args):
   parser.add_argument("--length", help="length of generated password (default 32)", default=32)
   parser.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
   parser.add_argument("--plaintext", help="secret to be encrypted rather than a randomly generated one", default="")
+  parser.add_argument("--region", help="region for the specified service, default is " + EFConfig.DEFAULT_REGION,
+                      default=EFConfig.DEFAULT_REGION)
   parsed_args = vars(parser.parse_args(args))
   context = EFPWContext()
   try:
@@ -99,6 +101,7 @@ def handle_args_and_set_context(args):
   context.decrypt = parsed_args["decrypt"]
   context.length = parsed_args["length"]
   context.plaintext = parsed_args["plaintext"]
+  context.region = parsed_args["region"]
   return context
 
 
@@ -107,10 +110,10 @@ def main():
   profile = None if context.whereami == "ec2" else context.account_alias
 
   try:
-    clients = ef_utils.create_aws_clients(EFConfig.DEFAULT_REGION, profile, "kms")
+    clients = ef_utils.create_aws_clients(context.region, profile, "kms")
   except RuntimeError as error:
     ef_utils.fail(
-      "Exception creating clients in region {} with profile {}".format(EFConfig.DEFAULT_REGION, profile),
+      "Exception creating clients in region {} with profile {}".format(context.region, profile),
       error
     )
 

--- a/src/ef-resolve-config.py
+++ b/src/ef-resolve-config.py
@@ -58,13 +58,15 @@ def handle_args_and_set_context(args):
   parser.add_argument("env", help="environment")
   parser.add_argument("path_to_template", help="path to the config template to process")
   parser.add_argument("--verbose", help="Output extra info", action="store_true", default=False)
+  parser.add_argument("--region", help="Region to resolve the config, default is " + EFConfig.DEFAULT_REGION,
+                      default=EFConfig.DEFAULT_REGION)
   parsed = vars(parser.parse_args(args))
   path_to_template = abspath(parsed["path_to_template"])
   service = path_to_template.split('/')[-3]
 
   return Context(
     get_account_alias(parsed["env"]),
-    EFConfig.DEFAULT_REGION, parsed["env"],
+    parsed["region"], parsed["env"],
     service, path_to_template,
     parsed["verbose"]
   )


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Adding initial region support for ef-open

## Changelog
  * Added `--region` option for `ef-cf`, `ef-generate`, `ef-password`, and `ef-resolve-config`

## Testing
```
000377-ml:ellation_formation jwong$ ef-cf cloudformation/services/templates/test-instance.json proto0 --devel --region us-east-2 --verbose
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
not refreshing repo because --devel was set or running on Jenkins
service_name: test-instance
env: proto0
env_full: proto0
env_short: proto
template_file: cloudformation/services/templates/test-instance.json
parameter_file: cloudformation/services/templates/../parameters/test-instance.parameters.proto0.json
profile: ellationeng
whereami: unknown
region: us-east-2
service type: aws_ec2
{'INSTANCE_ID': None, 'ACCOUNT': '', 'ROLE': None, 'SERVICE': 'test-instance', 'ENV': 'proto0', 'ACCOUNT_ALIAS': '', 'REGION': 'us-east-2', 'ENV_FULL': 'proto0', 'FUNCTION_NAME': None, 'ENV_SHORT': 'proto'}
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "proto0-test-instance",
  "Resources": {
    "Ec2Instance": {
      "Type": "AWS::EC2::Instance",
      "Properties": {
        "IamInstanceProfile": "proto0-test-instance",
        "InstanceType": "t2.medium",
        "ImageId": "ami-",
        "NetworkInterfaces": [{
          "AssociatePublicIpAddress": "true",
          "DeviceIndex": "0",
          "SubnetId": "{{aws:ec2:subnet/subnet-id,subnet-proto0-a}}",
          "GroupSet": [
            "{{aws:ec2:security-group/security-group-id,proto0-office-cidr-ingress}}",
            "{{aws:ec2:security-group/security-group-id,proto0-test-instance-ec2}}"
          ]
        }],
        "Tags": [{
          "Key": "Name",
          "Value": "proto0-test-instance"
        }]
      }
    }
  }
}

Unable to resolve symbols: {{aws:ec2:subnet/subnet-id,subnet-proto0-a}},{{aws:ec2:security-group/security-group-id,proto0-office-cidr-ingress}},{{aws:ec2:security-group/security-group-id,proto0-test-instance-ec2}}
```

```
000377-ml:ellation_formation jwong$ ef-generate proto0 --devel --region us-east-2
Not refreshing repo because --devel was set or running on Jenkins
=== DRY RUN ===
Use --commit to create roles and security groups
=== DRY RUN ===
env: proto0
env_full: proto0
env_short: proto
region: us-east-2
aws account profile: ellationeng
aws account number:
Create security group: proto0-cms-ie-videos-ec2 in vpc: vpc-proto0
Error: could not get VPC by name: vpc-proto0
000377-ml:ellation_formation jwong$
```

```
000377-ml:ellation_formation jwong$ ef-resolve-config proto0 configs/logs/templates/logstash.conf --region us-east-2
input {
  beats {
    type => beats
    port => 5000
  }
}

filter {
  fingerprint {
    source => ["[beat.hostname]","[input_type]", "%{YYYY-MM-DDTHH:MM:SS.milliZ}", "message"]
    target => "fingerprint"
    method => "UUID"
  }
}

output {
  sqs {
    queue => "proto0-logs"
    region => "us-east-2"
  }
}

000377-ml:ellation_formation jwong$
```