### PR TITLE
Ops 8556

### DIFF
--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -171,6 +171,16 @@ which is looked up in 'proto3' as:<br>
 returns:<br>
 ```sg-78fe34a6```<br>
 
+#### {{aws:ec2:subnet/subnet-cidr,\<subnet_friendly_name>}}
+Returns: subnet CIDR<br>
+Needs: Subnet's friendly name, which is always "subnet-\<env>-\<az>"<br>
+Example:<br>
+```{{aws:ec2:subnet/subnet-cidr,subnet-{{ENV}}-a}}```<br>
+which is looked up in 'proto3' as:<br>
+```{{aws:ec2:subnet/subnet-cidr,subnet-proto3-a}}```<br>
+returns:<br>
+```0.0.0.0/0```<br>
+
 #### {{aws:ec2:subnet/subnet-id,\<subnet_friendly_name>}}
 Returns: subnet ID<br>
 Needs: Subnet's friendly name, which is always "subnet-\<env>-\<az>"<br>

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -214,6 +214,23 @@ class EFAwsResolver(object):
     else:
       return default
 
+  def ec2_subnet_subnet_cidr(self, lookup, default=None):
+    """
+    Return:
+      the ID of a single subnet or default/None if no match
+    Args:
+      lookup: the friendly name of the subnet to look up (subnet-<env>-a or subnet-<env>-b)
+      default: the optional value to return if lookup failed; returns None if not set
+    """
+    subnets = EFAwsResolver.__CLIENTS["ec2"].describe_subnets(Filters=[{
+      'Name': 'tag:Name',
+      'Values': [lookup]
+    }])
+    if len(subnets["Subnets"]) > 0:
+      return subnets["Subnets"][0]["CidrBlock"]
+    else:
+      return default
+
   def ec2_vpc_availabilityzones(self, lookup, default=None):
     """
     Args:
@@ -512,6 +529,8 @@ class EFAwsResolver(object):
       return self.ec2_route_table_main_route_table_id(*kv[1:])
     elif kv[0] == "ec2:security-group/security-group-id":
       return self.ec2_security_group_security_group_id(*kv[1:])
+    elif kv[0] == "ec2:subnet/subnet-cidr":
+      return self.ec2_subnet_subnet_cidr(*kv[1:])
     elif kv[0] == "ec2:subnet/subnet-id":
       return self.ec2_subnet_subnet_id(*kv[1:])
     elif kv[0] == "ec2:vpc/availabilityzones":

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -572,6 +572,47 @@ class TestEFAwsResolver(unittest.TestCase):
     result = ef_aws_resolver.lookup("ec2:security-group/security-group-id,cant_possibly_match")
     self.assertIsNone(result)
 
+  def test_ec2_subnet_subnet_cidr(self):
+    """
+    Tests ec2_subnet_subnet_cidr to see if it returns a subnet CDIR based on matching subnet name in tag
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    target_subnet_cidr = "0.0.0.0/0"
+    subnet_response = {
+      "Subnets": [
+        {
+          "CidrBlock": target_subnet_cidr
+        }
+      ]
+    }
+    self._clients["ec2"].describe_subnets.return_value = subnet_response
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    result = ef_aws_resolver.lookup("ec2:subnet/subnet-cidr,target_subnet_name")
+    self.assertEquals(target_subnet_cidr, result)
+
+  def test_ec2_subnet_subnet_cidr_no_match(self):
+    """
+    Tests ec2_subnet_subnet_cidr to see if it returns None when there is no match
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    subnet_response = {
+      "Subnets": []
+    }
+    self._clients["ec2"].describe_subnets.return_value = subnet_response
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    result = ef_aws_resolver.lookup("ec2:subnet/subnet-cidr,cant_possibly_match")
+    self.assertIsNone(result)
+
   def test_ec2_subnet_subnet_id(self):
     """
     Tests ec2_subnet_subnet_id to see if it returns a subnet ID based on matching subnet name in tag


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
[OPS-8556](https://ellation.atlassian.net/browse/OPS-8556)

## Changelog
- add symbol reference to docs
- create tests
- add subnet cidr lookup

## Testing
============================= test session starts ==============================
platform darwin -- Python 2.7.10, pytest-3.2.2, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python
cachedir: Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/.cache
rootdir: /Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests, inifile:
plugins: cov-2.5.1
collecting ... collected 55 items
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_bad_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_multiple_matching_certificates PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_old_matching_certificate_has_no_issued_date PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_target_certificate_has_no_issued_date PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_id_bad_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_ipaddress PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_ipaddress_bad_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_eni_eni_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_eni_eni_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_network_network_acl_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_network_network_acl_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_route_table_main_route_table_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_route_table_main_route_table_id_no_single_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_security_group_security_group_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_security_group_security_group_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_cidr PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_cidr_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones_no_vpc_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_cidrblock PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_cidrblock_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_subnets PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_subnets_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_vpc_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_vpc_id_none PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_lookup_invalid_input PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_malformed_domain_name PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_is_truncated PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_malformed_domain_name PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id_more_rules_than_limit PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id_no_match PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id_more_web_acls_than_limit PASSED
Users/toverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id_no_match PASSED
 generated xml file: /var/folders/_7/5rwz5y3n2g7dl_m9gf2kdjyx8wq3lw/T/results4229Q0NfEqqr7HT2.xml 
========================== 55 passed in 0.26 seconds ===========================
