### PR TITLE
Changing ef-version s3 policy to have object be bucket-owner-full-control

### DIFF
--- a/src/ef-version.py
+++ b/src/ef-version.py
@@ -597,7 +597,7 @@ def cmd_set(context):
     print("would set key: {} with value: {} {} {} {} {}".format(s3_key, context.value, context.build_number, context.commit_hash, context.location, s3_version_status))
   else:
     context.aws_client("s3").put_object(
-      ACL = 'bucket-owner-read',
+      ACL = 'bucket-owner-full-control',
       Body = context.value,
       Bucket = EFConfig.S3_VERSION_BUCKET,
       ContentEncoding = EFConfig.S3_VERSION_CONTENT_ENCODING,


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Changing ef-version s3 policy to have object be bucket-owner-full-control

## Changelog
  * Changing ef-version s3 policy to have object be bucket-owner-full-control
