### PR TITLE
Initial commit to support encrypting parameters file with ef-password

### DIFF
--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -136,7 +136,7 @@ def generate_secret_file(file_path, pattern, service, environment, clients):
             encrypted_password = ef_utils.kms_encrypt(clients['kms'], service, environment, value)
             data["params"][environment][key] = format_secret(encrypted_password)
             changed = True
-    except KeyError as e:
+    except KeyError:
       ef_utils.fail("Error env: {} does not exist in parameters file".format(environment))
 
   if changed:

--- a/src/ef-password.py
+++ b/src/ef-password.py
@@ -141,7 +141,9 @@ def generate_secret_file(file_path, pattern, service, environment, clients):
 
   if changed:
     with open(file_path, "w") as encrypted_file:
-      json.dump(data, encrypted_file, indent=2)
+      json.dump(data, encrypted_file, indent=2, separators=(',', ': '))
+      # Writing new line here so it conforms to WG14 N1256 §5.1.1.1 (so github doesn't complain)
+      encrypted_file.write("\n")
 
 def handle_args_and_set_context(args):
   """

--- a/tests/test_data/test.cnf.parameters.json
+++ b/tests/test_data/test.cnf.parameters.json
@@ -1,0 +1,25 @@
+{
+  "dest": {
+    "path": "/srv/test-instances/test.cnf", 
+    "dir_perm": "755", 
+    "file_perm": "644", 
+    "user_group": "wwwuser:wwwuser"
+  }, 
+  "params": {
+    "default": {
+      "username": "foobar"
+    }, 
+    "test": {
+      "password": "mock_secret1"
+    },
+    "proto0": {
+      "password": "mock_secret2"
+    }, 
+    "staging": {
+      "password": "mock_secret3"
+    }, 
+    "prod": {
+      "password": "{{aws:kms:decrypt,AQICAHgKKKY71tobDHsDpqGJpxUVx1IxoYgan68yJy9Qn2fHfQFbZWSx2xCeWJWnOjAkWwaYAAAAZjBkBgkqhkiG9w0BBwagVzBVAgEAMFAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3M7VHlVrzvqbsrnjAgEQgCMjK+W1PoyJzkA43Qz9ioK22STjZvvy61mLxMBx9PUbjK+MWQ==}}"
+    }
+  }
+}


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Initial commit to support encrypting parameters file with ef-password. This new functionality will allow individuals to have a parameters file containing secret level data where they can call ef-password to encrypt all the contents inside of the file by matching on a certain key.

## Changelog
  * Added --secret_file and --match option to ef-password

## Testing
```
000377-ml:ellation_formation jwong$ cat configs/test-instances/parameters/test.cnf.parameters.json
{
  "dest": {
    "path": "/srv/test-instances/test.cnf",
    "dir_perm": "755",
    "file_perm": "644",
    "user_group": "wwwuser:wwwuser"
  },
  "params": {
    "default": {
      "username": "foobar"
    },
    "proto0": {
      "password": "passwordpassword",
      "password1": "mock_test1",
      "password2": "mock_test2",
      "password3": "mock_test3"
    },
    "staging": {
      "password": "passwordpassword",
      "password1": "mock_test1",
      "password2": "mock_test2",
      "password3": "mock_test3"
    },
    "prod": {
      "password": "passwordpassword",
      "password1": "mock_test1",
      "password2": "mock_test2",
      "password3": "mock_test3"
    }
  }
}
000377-ml:ellation_formation jwong$ ef-password test-instance proto0 --secret_file configs/test-instances/parameters/test.cnf.parameters.json --match password
Found match, encrypting value
Found match, encrypting value
Found match, encrypting value
Found match, encrypting value
000377-ml:ellation_formation jwong$ cat configs/test-instances/parameters/test.cnf.parameters.json
{
  "dest": {
    "path": "/srv/test-instances/test.cnf",
    "dir_perm": "755",
    "file_perm": "644",
    "user_group": "wwwuser:wwwuser"
  },
  "params": {
    "default": {
      "username": "foobar"
    },
    "proto0": {
      "password": "{{aws:kms:decrypt,AQICAHirVWOYed4lqv0b+HGK7d0aQyhoc1utUUPXKYJEQQi5IwFdIjIct7U2ZptCE+qr6jxuAAAAbjBsBgkqhkiG9w0BBwagXzBdAgEAMFgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMaO+j5zdgnEho106mAgEQgCu9MyIxJuNEVoIfRVfD8MQ26idCzUcd/RMwxMy7t+HwUltbd3VNB2t34tCe}}",
      "password1": "{{aws:kms:decrypt,AQICAHirVWOYed4lqv0b+HGK7d0aQyhoc1utUUPXKYJEQQi5IwGzxecKPz4iYalp+l4WHCHnAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/WrOZYAARsjWPlzfAgEQgCXPDK8kjRclD4njrKWMP7ryujNWO4KhzS4NP6cXIlTyguqs/9TQ}}",
      "password2": "{{aws:kms:decrypt,AQICAHirVWOYed4lqv0b+HGK7d0aQyhoc1utUUPXKYJEQQi5IwEXqmmDRa19s2OEkc1cM11mAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM8eGLLuOp8G2XM24sAgEQgCU64/+tEXdCh3dJoNqEiR63JOtByvU2jubl0kKtfffZ48aPxIk0}}",
      "password3": "{{aws:kms:decrypt,AQICAHirVWOYed4lqv0b+HGK7d0aQyhoc1utUUPXKYJEQQi5IwHokJtREqDdfqzCdj+2/vTvAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPMH2tKagqu4egpSNAgEQgCWt17CraYcg41+cvzhoMSFBwmPJH9VQqHxx11rMUqR4S6xjqZ/6}}"
    },
    "staging": {
      "password": "passwordpassword",
      "password1": "mock_test1",
      "password2": "mock_test2",
      "password3": "mock_test3"
    },
    "prod": {
      "password": "passwordpassword",
      "password1": "mock_test1",
      "password2": "mock_test2",
      "password3": "mock_test3"
    }
  }
000377-ml:ellation_formation jwong$ ef-password test-instance proto0 --decrypt AQICAHirVWOYed4lqv0b+HGK7d0aQyhoc1utUUPXKYJEQQi5IwHokJtREqDdfqzCdj+2/vTvAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPMH2tKagqu4egpSNAgEQgCWt17CraYcg41+cvzhoMSFBwmPJH9VQqHxx11rMUqR4S6xjqZ/6
Decrypted Secret: mock_test3
000377-ml:ellation_formation jwong$
000377-ml:ellation_formation jwong$ ef-resolve-config proto0 configs/test-instance/templates/test.cnf
dummy_username: foobar
dummy_password: passwordpassword
dummy_password1: mock_test1
dummy_password2: mock_test2
dummy_password3: mock_test3
```

More test:
```
000377-ml:ellation_formation jwong$ ef-password test-instance proto0 --secret_file configs/test-instance/parameters/test.cnf.parameters.json --match password
Found match, key password but value is encrypted already; skipping...
Found match, key password1 but value is encrypted already; skipping...
Found match, key password2 but value is encrypted already; skipping...
Found match, key password3 but value is encrypted already; skipping...
000377-ml:ellation_formation jwong$ ef-password test-instance proto1 --secret_file configs/test-instance/parameters/test.cnf.parameters.json --match password
Error env: proto1 does not exist in parameters file
000377-ml:ellation_formation jwong$ ef-password test-instance staging --secret_file configs/test-instance/parameters/test.cnf.parameters.json --match password
Found match, encrypting key password
Found match, encrypting key password1
Found match, encrypting key password2
Found match, encrypting key password3
000377-ml:ellation_formation jwong$ vim configs/test-instance/parameters/test.cnf.parameters.json
000377-ml:ellation_formation jwong$ ef-resolve-config proto0 configs/test-instance/templates/test.cnf
dummy_username: foobar
dummy_password: passwordpassword
dummy_password1: mock_test1
dummy_password2: mock_test2
dummy_password3: mock_test3


000377-ml:ellation_formation jwong$ vim configs/test-instance/templates/test.cnf
000377-ml:ellation_formation jwong$ ef-resolve-config staging configs/test-instance/templates/test.cnf
dummy_username: foobar
dummy_password: passwordpassword
dummy_password1: mock_test1
dummy_password2: mock_test2
dummy_password3: mock_test3


000377-ml:ellation_formation jwong$
```