### PR TITLE
fix eip lookups with variable env

### DIFF
--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -128,8 +128,10 @@ class EFAwsResolver(object):
     # The lookup string was not a valid ElasticIp resource label
     if m is None:
       return default
-    env = m.group(1).lower()
-    stackname = "{}-elasticip".format(env)
+    env = m.group(1)
+    stackname = "{}-elasticip".format(env.lower())
+    # Convert env substring to title in case {{ENV}} substitution is being used
+    lookup = lookup.replace(env, env.title())
     # Look up the EIP resource in the stack to get the IP address assigned to the EIP
     try:
       eip_stack = EFAwsResolver.__CLIENTS["cloudformation"].describe_stack_resources(


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
This fixes elasticip lookups that contain the {{ENV}} variable. By convention we capitalize the env in the resource name of the elasticip, however the rendered {{ENV}} value is always lower case. This will cause the lookup to fail. 
## Changelog
- Convert env substring of lookup to title case
## Testing
**cloudformation/fixtures/templates/elasticip.json**
```
"ElasticIpProdPartnerFtp1": {
      "Type": "AWS::EC2::EIP",
      "Condition": "EnvIsProd",
      "Properties": {
        "Domain": "vpc"
      }
    },
...
"ElasticIpStagingPartnerFtp1": {
      "Type": "AWS::EC2::EIP",
      "Condition": "EnvIsStaging",
      "Properties": {
        "Domain": "vpc"
      }
    },
```
**cf template**
```
"EIPAssociation": {
      "Type": "AWS::EC2::EIPAssociation",
      "Condition": "IsMultiZone",
      "Properties": {
        "InstanceId": { "Ref": "Ec2Instance" },
        "AllocationId": "{{aws:ec2:elasticip/elasticip-id,ElasticIp{{ENV}}PartnerFtp1,None}}"
      }
    },
```
**cf-ef before**
```
± |master {5} ✓| → ef-cf cloudformation/services/templates/partners-sftp.json staging --verbose
...
    "EIPAssociation": {
      "Type": "AWS::EC2::EIPAssociation",
      "Condition": "IsMultiZone",
      "Properties": {
        "InstanceId": { "Ref": "Ec2Instance" },
        "AllocationId": "None"  <--- (lookup fails so default value is returned)
      }
    },
...
```

**ef-cf after**
```
± |master {5} ✓| → ef-cf cloudformation/services/templates/partners-sftp.json staging --verbose
...
    "EIPAssociation": {
      "Type": "AWS::EC2::EIPAssociation",
      "Condition": "IsMultiZone",
      "Properties": {
        "InstanceId": { "Ref": "Ec2Instance" },
        "AllocationId": "eipalloc-7beb0b47"  <--- (lookup is successful)
      }
    },
...
```
