### PR TITLE
allow numbers in env name (eg. proto0)

### DIFF
--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -124,7 +124,7 @@ class EFAwsResolver(object):
       The IP address of the first Elastic IP found with a description matching 'lookup' or default/None if no match
     """
     # Extract environment from resource ID to build stack name
-    m = re.search('ElasticIp([A-Z]?[a-z]+)\w+', lookup)
+    m = re.search('ElasticIp([A-Z]?[a-z]+[0-9]?)\w+', lookup)
     # The lookup string was not a valid ElasticIp resource label
     if m is None:
       return default


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
optional number in eip regex validator to account for numbered environments (e.g. proto0)
## Testing
```
± |eip_lookup_num {2} ?:1 ✗| → python
Python 2.7.13 (default, Apr  4 2017, 08:47:57)
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> lookup = "ElasticIpproto0MyService1"
>>> m = re.search('ElasticIp([A-Z]?[a-z]+[0-9]?)\w+', lookup)
>>> env = m.group(1)
>>> print(env)
proto0
>>> lookup = lookup.replace(env, env.title())
>>> print(lookup)
ElasticIpProto0MyService1
```

