### PR TITLE
Route table lookup

### DIFF
--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -161,6 +161,14 @@ which is looked up in 'prod' as:<br>
 returns:<br>
 ```rtb-3f820be9a```<br>
 
+#### {{aws:ec2:route-table/tagged-route-table-id,\<route_table_name>}}
+Returns: Route table ID<br>
+Needs: the tagged route table name, should be unique<br>
+Example:<br>
+```{{aws:ec2:route-table/tagged-route-table-id,{{ENV}}-dmz}}```<br>
+returns:<br>
+```rtb-3f820be9a```<br>
+
 #### {{aws:ec2:security-group/security-group-id,\<sg_friendly_name>}}
 Returns: Security group ID<br>
 Needs: Security group's friendly name<br>

--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -124,7 +124,7 @@ class EFAwsResolver(object):
       The IP address of the first Elastic IP found with a description matching 'lookup' or default/None if no match
     """
     # Extract environment from resource ID to build stack name
-    m = re.search('ElasticIp([A-Z]?[a-z]+)\w+', lookup)
+    m = re.search('ElasticIp([A-Z]?[a-z]+[0-9]?)\w+', lookup)
     # The lookup string was not a valid ElasticIp resource label
     if m is None:
       return default


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Allows lookups of subnets beyond the vpc default
## Changelog
- add tagged-route-table-id lookup in ef_aws_resolver
## Testing
```
"vpnRoutePropagation": {
      "Type": "AWS::EC2::VPNGatewayRoutePropagation",
      "DependsOn": [ "vpnGateway", "vpnToVpcAttachment" ],
      "Properties": {
        "RouteTableIds": [ "{{aws:ec2:route-table/main-route-table-id,vpc-{{ENV}}}}", "{{aws:ec2:route-table/tagged-route-table-id,{{ENV}}-test}}" ],
        "VpnGatewayId": { "Ref": "vpnGateway" }
      }
    },
```
```
py-2.7.13 000612-ml in ~/workspace/cde/ellation-formation-c
± |update_routing U:3 ✗| → ../dist/ef-cf cloudformation/fixtures/templates/vpn.json proto0 --verbose --devel
...
"vpnRoutePropagation": {
      "Type": "AWS::EC2::VPNGatewayRoutePropagation",
      "DependsOn": [ "vpnGateway", "vpnToVpcAttachment" ],
      "Properties": {
        "RouteTableIds": [ "rtb-abc12345", "rtb-abc123456" ],
        "VpnGatewayId": { "Ref": "vpnGateway" }
      }
    },
```
