### PR TITLE
Fail ef-cf on stack rollback OPS-9082

### DIFF
--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -271,7 +271,10 @@ def main():
           stack_status = clients["cloudformation"].describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]
           if context.verbose:
             print("{}".format(stack_status))
-          if re.match(r".*_COMPLETE(?!.)", stack_status) is not None:
+          if stack_status.endswith('ROLLBACK_COMPLETE'):
+            print("Stack went into rollback with status: {}".format(stack_status))
+            sys.exit(1)
+          elif re.match(r".*_COMPLETE(?!.)", stack_status) is not None:
             break
           elif re.match(r".*_FAILED(?!.)", stack_status) is not None:
             print("Stack failed with status: {}".format(stack_status))


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
ef-cf does not fail on a stack rollback. This results in unexpected behaviour as scripts and pipelines that rely on ef-cf not notifying of the failure.
[OPS-9082](https://ellation.atlassian.net/browse/OPS-9082)
## Changelog
- add a check for `ROLLBACK_COMPLETE` and fail on it
## Testing
Simple scenario
1. pick a stack with a database;
2. increase the database storage;
3. deploy same stack with smaller database size using ef-cf
4. ef-cf fails with `UPDATE_ROLLBACK_COMPLETE` message; `echo $?` should not be 0