### PR TITLE
OPS-9597 Update the ef-generate for KMS policy 

### DIFF
--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -434,7 +434,7 @@ def conditionally_create_kms_key(role_name, service_type):
         "Resource": "*"
       },
       {
-        "Sid": "Allow use of the key",
+        "Sid": "Allow use of the key for default autoscaling group service role",
         "Effect": "Allow",
         "Principal": { AWS: arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling },
         "Action": [
@@ -447,7 +447,7 @@ def conditionally_create_kms_key(role_name, service_type):
         "Resource": "*"
       },
       {
-        "Sid": "Allow attachment of persistent resources",
+        "Sid": "Allow attachment of persistent resourcesfor default autoscaling group service role",
         "Effect": "Allow",
         "Principal": { AWS: arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling },
         "Action": [

--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -410,7 +410,34 @@ def conditionally_create_kms_key(role_name, service_type):
         "Principal": { ''' + formatted_principal + ''' },
         "Action": "kms:Decrypt",
         "Resource": "*"
-      }
+      },
+      {
+        "Sid": "Allow use of the key",
+        "Effect": "Allow",
+        "Principal": { AWS: arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling },
+        "Action": [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "Allow attachment of persistent resources",
+        "Effect": "Allow",
+        "Principal": { AWS: arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling },
+        "Action": [
+          "kms:CreateGrant"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "Bool": {
+            "kms:GrantIsForAWSResource": true
+          }
+        }
+      }      
     ]
   }'''
 


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Updated the key policy attached to the service's KMS to allow the default service linked role for autoscaling groups the ability to decrypt amis
[OPS-9597](https://ellation.atlassian.net/browse/OPS-9597)

## Changelog
Updated the ef-generate for kms

## Dependencies
None

## Linked PRs
None

## Testing
The policy is what I manually pasted into cde proto0

###### [Markdown support](https://guides.github.com/features/mastering-markdown/)
