### PR TITLE
Ops 9679

### DIFF
--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -340,6 +340,29 @@ def conditionally_create_profile(role_name, service_type):
   else:
     print_if_verbose("instance profile already contains role: {}".format(role_name))
 
+def conditionally_attach_managed_policies(role_name, sr_entry):
+  """
+  If 'aws_managed_policies' key lists the names of AWS managed policies to bind to the role,
+  attach them to the role
+  Args:
+    role_name: name of the role to attach the policies to
+    sr_entry: service registry entry
+  """
+  service_type = sr_entry['type']
+  if not (service_type in SERVICE_TYPE_ROLE and "aws_managed_policies" in sr_entry):
+    print_if_verbose("not eligible for policies; service_type: {} is not valid for policies "
+                     "or no 'aws_managed_policies' key in service registry for this role".format(service_type))
+    return
+
+  for policy_name in sr_entry['aws_managed_policies']:
+    print_if_verbose("loading policy: {} for role: {}".format(policy_name, role_name))
+
+    if CONTEXT.commit:
+      try:
+        CLIENTS["iam"].attach_role_policy(RoleName=role_name, PolicyArn='arn:aws:iam::aws:policy/' + policy_name)
+      except:
+        fail("Exception putting policy: {} onto role: {}".format(policy_name, role_name), sys.exc_info())
+
 def conditionally_inline_policies(role_name, sr_entry):
   """
   If 'policies' key lists the filename prefixes of policies to bind to the role,
@@ -349,7 +372,7 @@ def conditionally_inline_policies(role_name, sr_entry):
     sr_entry: service registry entry
   """
   service_type = sr_entry['type']
-  if not (service_type in SERVICE_TYPE_ROLE and sr_entry.has_key("policies")):
+  if not (service_type in SERVICE_TYPE_ROLE and "policies" in sr_entry):
     print_if_verbose("not eligible for policies; service_type: {} is not valid for policies "
                      "or no 'policies' key in service registry for this role".format(service_type))
     return
@@ -367,7 +390,6 @@ def conditionally_inline_policies(role_name, sr_entry):
         CLIENTS["iam"].put_role_policy(RoleName=role_name, PolicyName=policy_name, PolicyDocument=policy_document)
       except:
         fail("Exception putting policy: {} onto role: {}".format(policy_name, role_name), sys.exc_info())
-
 
 def conditionally_create_kms_key(role_name, service_type):
   """
@@ -519,7 +541,10 @@ def main():
     # 3. KMS KEY FOR THE SERVICE : only some types of services get kms keys
     conditionally_create_kms_key(target_name, service_type)
 
-    # 4. INLINE SERVICE'S POLICIES INTO ROLE
+    # 4 ATTACH AWS MANAGED POLICIES TO ROLE
+    conditionally_attach_managed_policies(target_name, sr_entry)
+
+    # 5. INLINE SERVICE'S POLICIES INTO ROLE
     # only eligible service types with "policies" sections in the service registry get policies
     conditionally_inline_policies(target_name, sr_entry)
 

--- a/tests/test_data/test_service_registry_1.json
+++ b/tests/test_data/test_service_registry_1.json
@@ -1,5 +1,24 @@
 {
   "fixtures": {
+    "test-role": {
+      "type": "aws_role",
+      "description": "test role",
+      "runbook_url": "https://www.google.com/",
+      "team_email": "email@example.com",
+      "environments": ["global.ellationeng"],
+      "aws_managed_policies": ["AwsManagedPolicy"],
+      "policies": ["policy_1", "policy_2"],
+      "assume_role_policy": "assume_role_policy"
+    },
+    "test-role-2": {
+      "type": "aws_role",
+      "description": "test role",
+      "runbook_url": "https://www.google.com/",
+      "team_email": "email@example.com",
+      "environments": ["global.ellationeng"],
+      "policies": ["policy_1", "policy_2"],
+      "assume_role_policy": "assume_role_policy"
+    }
   },
   "platform_services": {
     "test-instance": {

--- a/tests/unit_tests/test_ef_generate.py
+++ b/tests/unit_tests/test_ef_generate.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
+import json
 import unittest
 
 from botocore.exceptions import ClientError
@@ -26,20 +28,58 @@ ef_generate = __import__("ef-generate")
 
 class TestEFGenerate(unittest.TestCase):
   def setUp(self):
+    self.role_name = "global-test-role"
     self.service_name = "proto0-test-service"
     self.service_type = "http_service"
+    self.service_registry_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                              '../test_data/test_service_registry_1.json'))
+    with open(self.service_registry_file, "r") as sr:
+      self.service_registry = json.load(sr)
     self.malformed_policy_response = {'Error': {'Code': 'MalformedPolicyDocumentException',
                                                 'Message': 'Error creating key'}}
     self.malformed_policy_client_error = ClientError(self.malformed_policy_response, "create_key")
     self.not_found_response = {'Error': {'Code': 'NotFoundException', 'Message': 'Error describing key'}}
     self.not_found_client_error = ClientError(self.not_found_response, "describe_key")
+    self.mock_iam = Mock(name="mocked iam client")
+    self.mock_iam.attach_role_policy.return_value = {}
     self.mock_kms = Mock(name="mocked kms client")
     self.mock_kms.create_key.return_value = {"KeyMetadata": {"KeyId": "1234"}}
     self.mock_kms.describe_key.side_effect = self.not_found_client_error
     ef_generate.CONTEXT = EFContext()
     ef_generate.CONTEXT.commit = True
     ef_generate.CONTEXT.account_id = "1234"
-    ef_generate.CLIENTS = {"kms": self.mock_kms}
+    ef_generate.CLIENTS = {"kms": self.mock_kms, "iam": self.mock_iam}
+
+  def test_attach_managed_policies(self):
+    """
+    Check that when an existing key is not found that the create key/alias methods are called with the correct
+    parameters.
+    """
+    ef_generate.conditionally_attach_managed_policies(self.role_name,
+                                                      self.service_registry['fixtures']['test-role'])
+
+    self.mock_iam.attach_role_policy.assert_called_with(
+      RoleName=self.role_name,
+      PolicyArn='arn:aws:iam::aws:policy/{}'.format(self.service_registry['fixtures']['test-role']['aws_managed_policies'][0])
+    )
+
+  def test_not_service_type_for_managed_policy(self):
+    """
+    Validates that a managed policy is not attached for unsupported service types
+    """
+    self.service_type = {"type": "invalid_service"}
+    ef_generate.conditionally_attach_managed_policies(self.role_name, self.service_type)
+
+    self.mock_iam.attach_role_policy.assert_not_called()
+
+  def test_no_aws_managed_policies_key_in_service(self):
+    """
+    Validates that a managed policy is not attached services without the 'aws_managed_policies' key
+    """
+    ef_generate.conditionally_attach_managed_policies(self.role_name,
+                                                      self.service_registry['fixtures']['test-role-2'])
+
+    self.mock_iam.attach_role_policy.assert_not_called()
 
   def test_create_kms_key(self):
     """


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
[OPS-9679](https://ellation.atlassian.net/browse/OPS-9679)

## Changelog
- create logic to conditionally attach managed policies

## Testing
```
Running tests... 
 
============================= test session starts ==============================
platform darwin -- Python 2.7.10, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /Users/thomasoverton/Documents/Ellation/dev/ef-open/tests/unit_tests, inifile:
collected 9 items
Users/thomasoverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_generate.py . [ 11%]
........                                                                 [100%]
 generated xml file: /var/folders/qs/_5fhx7zd05vdk8096x9pjg580000gn/T/results1005VvXYJCrriit1.xml 
=========================== 9 passed in 1.31 seconds ===========================
```