### PR TITLE
OPS-9670 Add feature for ef-open to lookup full kms key arn given the key alias

### DIFF
--- a/src/ef_aws_resolver.py
+++ b/src/ef_aws_resolver.py
@@ -523,6 +523,16 @@ class EFAwsResolver(object):
     decrypted_lookup = ef_utils.kms_decrypt(EFAwsResolver.__CLIENTS["kms"], lookup)
     return decrypted_lookup
 
+  def kms_key_arn(self, lookup):
+    """
+    Args:
+      lookup: The key alias, EX: alias/proto0-evs-drm
+    Returns:
+      The full key arn
+    """
+    key_arn = ef_utils.kms_key_arn(EFAwsResolver.__CLIENTS["kms"], lookup)
+    return key_arn
+
   def lookup(self, token):
     try:
       kv = token.split(",")
@@ -564,6 +574,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_vpc_id(*kv[1:])
     elif kv[0] == "kms:decrypt":
       return self.kms_decrypt_value(*kv[1:])
+    elif kv[0] == "kms:key_arn":
+      return self.kms_key_arn(*kv[1:])
     elif kv[0] == "route53:private-hosted-zone-id":
       return self.route53_private_hosted_zone_id(*kv[1:])
     elif kv[0] == "route53:public-hosted-zone-id":

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -318,3 +318,21 @@ def kms_decrypt(kms_client, secret):
     else:
       fail("boto3 exception occurred while performing kms decrypt operation.", error)
   return decrypted_secret
+
+def kms_key_arn(kms_client, alias):
+  """
+  Obtain the full key arn based on the key alias provided
+  Args:
+    kms_client (boto3 kms client object): Instantiated kms client object. Usually created through create_aws_clients.
+    alias (string): alias of key, example alias/proto0-evs-drm.
+
+  Returns:
+    string of the full key arn
+  """
+  try:
+    response = kms_client.describe_key(KeyId=alias)
+    key_arn = response["KeyMetadata"]["Arn"]
+  except ClientError as error:
+    raise RuntimeError("Failed to obtain key arn for alias {}, error: {}".format(alias, error.response["Error"]["Message"]))
+
+  return key_arn


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Add feature for ef-open to lookup full kms key arn given the key alias
[OPS-9670](https://ellation.atlassian.net/browse/OPS-9670)
## Changelog
Updated ef_aws_resolver, ef_utils, and unit tests

## Dependencies
None

## Linked PRs
None

## Testing
Ran the unit tests

###### [Markdown support](https://guides.github.com/features/mastering-markdown/)
