### PR TITLE
Fix misquoted kms_policy params

### DIFF
--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -436,7 +436,7 @@ def conditionally_create_kms_key(role_name, service_type):
       {
         "Sid": "Allow use of the key for default autoscaling group service role",
         "Effect": "Allow",
-        "Principal": { AWS: arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling },
+        "Principal": { "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" },
         "Action": [
           "kms:Encrypt",
           "kms:Decrypt",
@@ -449,7 +449,7 @@ def conditionally_create_kms_key(role_name, service_type):
       {
         "Sid": "Allow attachment of persistent resourcesfor default autoscaling group service role",
         "Effect": "Allow",
-        "Principal": { AWS: arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling },
+        "Principal": { "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" },
         "Action": [
           "kms:CreateGrant"
         ],


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Fix misquoted KMS policy
[OPS-9885](https://ellation.atlassian.net/browse/OPS-9885)
## Changelog
- add quotes to json-like string for policy
## Testing
Ran ef-generate on alpha0.