### PR TITLE
Ops 10051

### DIFF
--- a/src/ef-generate.py
+++ b/src/ef-generate.py
@@ -43,7 +43,7 @@ from ef_context import EFContext
 from ef_plugin import run_plugins
 from ef_service_registry import EFServiceRegistry
 from ef_template_resolver import EFTemplateResolver
-from ef_utils import create_aws_clients, fail, http_get_metadata, pull_repo
+from ef_utils import create_aws_clients, fail, get_account_id, http_get_metadata, pull_repo
 
 # Globals
 CLIENTS = None
@@ -459,7 +459,7 @@ def conditionally_create_kms_key(role_name, service_type):
             "kms:GrantIsForAWSResource": true
           }
         }
-      }      
+      }
     ]
   }'''
 
@@ -517,8 +517,8 @@ def main():
       CONTEXT.account_id = str(json.loads(http_get_metadata('iam/info'))["InstanceProfileArn"].split(":")[4])
     else:
       # Otherwise, we use local user creds based on the account alias
-      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, CONTEXT.account_alias, "ec2", "iam", "kms")
-      CONTEXT.account_id = CLIENTS["SESSION"].resource('iam').CurrentUser().arn.split(':')[4]
+      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, CONTEXT.account_alias, "ec2", "iam", "kms", "sts")
+      CONTEXT.account_id = get_account_id(CLIENTS["sts"])
   except RuntimeError:
     fail("Exception creating AWS clients in region {} with profile {}".format(
       EFConfig.DEFAULT_REGION, CONTEXT.account_alias))

--- a/src/ef_template_resolver.py
+++ b/src/ef_template_resolver.py
@@ -25,7 +25,7 @@ import botocore.exceptions
 from ef_aws_resolver import EFAwsResolver
 from ef_config import EFConfig
 from ef_config_resolver import EFConfigResolver
-from ef_utils import create_aws_clients, fail, http_get_metadata, whereami
+from ef_utils import create_aws_clients, fail, get_account_id, http_get_metadata, whereami
 from ef_version_resolver import EFVersionResolver
 
 # CONSTANTS
@@ -238,7 +238,7 @@ class EFTemplateResolver(object):
       try:
         EFTemplateResolver.__CLIENTS = create_aws_clients(self.resolved["REGION"], profile,
                                                           "cloudformation", "cloudfront", "ec2", "iam", "kms",
-                                                          "lambda", "route53", "s3", "waf")
+                                                          "lambda", "route53", "s3", "sts", "waf")
       except RuntimeError as error:
         fail("Exception logging in with Session()", error)
 
@@ -290,7 +290,7 @@ class EFTemplateResolver(object):
           if whereami() == "ec2":
             self.resolved["ACCOUNT"] = str(json.loads(http_get_metadata('iam/info'))["InstanceProfileArn"].split(":")[4])
           else:
-            self.resolved["ACCOUNT"] = EFTemplateResolver.__CLIENTS["iam"].get_user()["User"]["Arn"].split(":")[4]
+            self.resolved["ACCOUNT"] = get_account_id(EFTemplateResolver.__CLIENTS["sts"])
         except botocore.exceptions.ClientError as error:
           fail("Exception in get_user()", error)
         self.resolved["ENV"] = env

--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -220,6 +220,13 @@ def get_account_alias(env):
       raise ValueError("generic env: {} has no entry in ENV_ACCOUNT_MAP of ef_site_config.py".format(env_short))
     return EFConfig.ENV_ACCOUNT_MAP[env_short]
 
+def get_account_id(sts_client):
+  """
+  Args:
+    sts_client (boto3 sts client object): Instantiated sts client object. Usually created through create_aws_clients
+  """
+  return sts_client.get_caller_identity().get('Account')
+
 def get_env_short(env):
   """
   Given an env, return <env_short> if env is valid

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -593,6 +593,21 @@ class TestEFUtils(unittest.TestCase):
       ef_utils.get_account_alias(None)
     self.assertTrue("unknown env" in exception.exception.message)
 
+  def test_get_account_id(self):
+    """
+    Checks if get_account_id returns the correct account id
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    target_account_id = "123456789"
+    mock_sts_client = Mock(name="mock sts client")
+    mock_sts_client.get_caller_identity.return_value.get.return_value = target_account_id
+    self.assertEquals(ef_utils.get_account_id(mock_sts_client), target_account_id)
+
   def test_get_env_short(self):
     """
     Checks if get_env_short returns the correct environment shortname when given valid environments


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Add support for assumed role usage of ef tools.
[OPS-10051](https://ellation.atlassian.net/browse/OPS-10051)

## Changelog
- create get_account_id test
- create method to centralize lookup logic
- create sts client and use account id lookup

## Testing
```
============================= test session starts ==============================
platform darwin -- Python 2.7.10, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /Users/thomasoverton/Documents/Ellation/dev/ef-open/tests/unit_tests, inifile:
collected 39 items
Users/thomasoverton/Documents/Ellation/dev/ef-open/tests/unit_tests/test_ef_utils.py . [  2%]
......................................                                   [100%]
 generated xml file: /var/folders/qs/_5fhx7zd05vdk8096x9pjg580000gn/T/results61283fUByHc09tRM.xml 
========================== 39 passed in 2.43 seconds ===========================
```