### PR TITLE
Cache aws clients

### DIFF
--- a/src/ef_utils.py
+++ b/src/ef_utils.py
@@ -43,6 +43,7 @@ CIDR_REGEX = r"^(([1-2][0-9]{2}|[0-9]{0,2})\.){3}([1-2][0-9]{2}|[0-9]{0,2})\/([1
 # Cache for AWS clients. Keeps all the clients under (region, profile) keys.
 client_cache = {}
 
+
 def fail(message, exception_data=None):
   """
   Print a failure message and exit nonzero
@@ -204,7 +205,7 @@ def create_aws_clients(region, profile, *clients):
       session = boto3.Session(region_name=region, profile_name=profile)
       aws_clients["SESSION"] = session
     # build clients
-    client_dict = { c: session.client(c) for c in new_clients }
+    client_dict = {c: session.client(c) for c in new_clients}
     # append the session itself in case it's needed by the client code - can't get it from the clients themselves
     aws_clients.update(client_dict)
 

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -679,11 +679,16 @@ class TestEFUtils(unittest.TestCase):
     region, profile = "us-west-2", "testing"
 
     clients = ef_utils.create_aws_clients(region, profile, *amazon_services)
+    # copy the old clients, so they're not overwritten
+    built_clients = {k: v for k, v in clients.items()}
     new_clients = ef_utils.create_aws_clients(region, profile, *new_amazon_services)
+
 
     for service in new_amazon_services:
       self.assertIn(service, new_clients)
 
+    for service, client in built_clients.items():
+      self.assertEquals(new_clients.get(service), client)
 
   def test_get_account_alias(self):
     """

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -641,7 +641,6 @@ class TestEFUtils(unittest.TestCase):
     built_clients = {k: v for k, v in clients.items()}
     new_clients = ef_utils.create_aws_clients(region, profile, *new_amazon_services)
 
-
     for service in new_amazon_services:
       self.assertIn(service, new_clients)
 

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -51,7 +51,8 @@ class TestEFUtils(unittest.TestCase):
     Returns:
       None
     """
-    pass
+    # reset the client cache after every run
+    ef_utils.client_cache = {}
 
   @patch('sys.stderr', new_callable=StringIO)
   def test_fail_with_message(self, mock_stderr):
@@ -639,12 +640,18 @@ class TestEFUtils(unittest.TestCase):
     mock_session.client.side_effect = lambda *args, **kwargs: Mock(name="mock-boto3-session")
     mock_session_constructor.return_value = mock_session
     amazon_services = ["acm", "batch", "ec2", "sqs"]
-    region, profile = "us-west-2a", "testing"
+    cases = [
+        ("us-west-2d", None),
+        ("us-west-3d", None),
+        ("us-west-2d", "codemobs"),
+        ("us-west-2d", "ellationeng"),
+        ("", None),
+    ]
+    for region, profile in cases:
+      clients1 = ef_utils.create_aws_clients(region, profile, *amazon_services)
+      clients2 = ef_utils.create_aws_clients(region, profile, *amazon_services)
 
-    clients1 = ef_utils.create_aws_clients(region, profile, *amazon_services)
-    clients2 = ef_utils.create_aws_clients(region, profile, *amazon_services)
-
-    self.assertEquals(clients1, clients2, msg="Should get the same clients for the same region/profile pair")
+      self.assertEquals(clients1, clients2, msg="Should get the same clients for the same region/profile pair")
 
   def test_get_account_alias(self):
     """

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -534,6 +534,33 @@ class TestEFUtils(unittest.TestCase):
     self.assertTrue("sqs" in client_dict)
     self.assertTrue("SESSION" in client_dict)
 
+  @patch('boto3.Session')
+  def test_create_aws_clients_cache(self, mock_session_constructor):
+    """
+    Test create_aws_clients with all the parameters except profile and mocking
+    the boto3 Session constructor.
+    Check that the returned clients are present in the client cache under the
+    (region, profile) key.
+
+    Args:
+      mock_session_constructor: MagicMock, returns Mock object representing a boto3.Session object
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    mock_session = Mock(name="mock-boto3-session")
+    mock_session.client.return_value = Mock(name="mock-client")
+    mock_session_constructor.return_value = mock_session
+    amazon_services = ["acm", "batch", "ec2", "sqs"]
+
+    client_dict = ef_utils.create_aws_clients("us-west-2d", None, *amazon_services)
+    cached_clients = ef_utils.client_cache.get(("us-west-2d", None))
+
+    self.assertEquals(client_dict, cached_clients)
+
   def test_get_account_alias(self):
     """
     Checks if get_account_alias returns the correct account based on valid environments

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -617,6 +617,35 @@ class TestEFUtils(unittest.TestCase):
           built_clients.get(case),
           ef_utils.client_cache.get(case))
 
+  @patch('boto3.Session')
+  def test_create_aws_clients_cache_same_client(self, mock_session_constructor):
+    """
+    Test create_aws_clients with same parameters and mocking the boto3
+    Session constructor.
+
+    Check that we get the same clients every time.
+
+    Args:
+      mock_session_constructor: MagicMock, returns Mock object representing a boto3.Session object
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    mock_session = Mock(name="mock-boto3-session")
+    # make sure we get different clients on every call
+    mock_session.client.side_effect = lambda *args, **kwargs: Mock(name="mock-boto3-session")
+    mock_session_constructor.return_value = mock_session
+    amazon_services = ["acm", "batch", "ec2", "sqs"]
+    region, profile = "us-west-2a", "testing"
+
+    clients1 = ef_utils.create_aws_clients(region, profile, *amazon_services)
+    clients2 = ef_utils.create_aws_clients(region, profile, *amazon_services)
+
+    self.assertEquals(clients1, clients2, msg="Should get the same clients for the same region/profile pair")
+
   def test_get_account_alias(self):
     """
     Checks if get_account_alias returns the correct account based on valid environments


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
While looking into ef-generate failing due to throttling, I profiled the command. The resulting profile has revealed that he command is wasting a lot of time to recreate and reconnect the AWS clients, as a result of constantly calling `resolve_policy_document`.

This PR implements a basic caching mechanism for the `create_aws_clients`. Based on my tests, the caching speeds up ef-generate by a factor of at least 2. See attached profiles for details.

The rationale for caching the clients:
- a session client is a long lived object; there is no need to create new clients per API request
- creating new clients is expensive: every new client initiates a connection to the API,  which take up the bulk of the execution time.

### Profiles
Without client caching:
https://drive.google.com/open?id=1A3dkFzFnJ9R4uwueKTKBJxayZM31N3Pk
![image](https://user-images.githubusercontent.com/7412752/42877064-2ba17350-8a91-11e8-87fe-6ed04b821a83.png)
With client caching:
https://drive.google.com/open?id=1Iy0s5ucxzfVxMslUKL2l9NAZ2FCaIVMm
![image](https://user-images.githubusercontent.com/7412752/42877092-403effee-8a91-11e8-8b5a-76af1fbaae5d.png)

The software used to interpret the profiles is [runsnakerun].(http://www.vrplumber.com/programming/runsnakerun/).
## Changelog
- add client caching for `create_aws_clients`
## Testing
A profile can be generated by using this command:
```
cd ellation_formation
python -m cProfile -o ef-generate.profile $EF_OPEN_DIR/src/ef-generate.py alpha0 --devel --verbose
```