### PR TITLE
Fix failing template_resolver_test

### DIFF
--- a/tests/unit_tests/test_ef_template_resolver.py
+++ b/tests/unit_tests/test_ef_template_resolver.py
@@ -89,6 +89,7 @@ class TestEFTemplateResolver(unittest.TestCase):
     mock_lambda_client = Mock(name="Mock Lambda Client")
     mock_route_53_client = Mock(name="Mock Route 53 Client")
     mock_s3_client = Mock(name="Mock S3 Client")
+    mock_sts_client = Mock(name="Mock STS Client")
     mock_waf_client = Mock(name="Mock WAF Client")
     mock_session = Mock(name="Mock Client")
 
@@ -103,6 +104,7 @@ class TestEFTemplateResolver(unittest.TestCase):
         "lambda": mock_lambda_client,
         "route53": mock_route_53_client,
         "s3": mock_s3_client,
+        "sts": mock_sts_client,
         "waf": mock_waf_client,
         "SESSION": mock_session
     }


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Following 2c50ab3, the `test_ef_template_resolver.py` test was failing due to a missing mock in the list of clients.
## Changelog
- add the STS mock to `test_ef_template_resolver.py`