### PR TITLE
Update newrelic

### DIFF
--- a/plugins_available/newrelic/executor.py
+++ b/plugins_available/newrelic/executor.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 import logging
 
+from ef_config import EFConfig
 from ef_plugin import ef_plugin
 from ef_utils import kms_decrypt
-from ef_config import EFConfig
 
 from interface import NewRelic, AlertPolicy
 

--- a/plugins_available/newrelic/executor.py
+++ b/plugins_available/newrelic/executor.py
@@ -43,9 +43,6 @@ class NewRelicAlerts(object):
     return condition_obj
 
   def run(self):
-    print("check 1")
-    print(self.context.env)
-    print(self.__dict__)
     if self.context.env in self.all_notification_channels.keys():
       if self.config['token_kms_encrypted']:
         self.admin_token = kms_decrypt(self.clients['kms'], self.admin_token)

--- a/plugins_available/newrelic/interface.py
+++ b/plugins_available/newrelic/interface.py
@@ -149,7 +149,7 @@ class NewRelic(object):
     add_condition = requests.post(
       url='https://infra-api.newrelic.com/v2/alerts/conditions',
       headers=self.auth_header,
-      data=json.dumps({ "data": condition })
+      data=json.dumps({"data": condition})
     )
     add_condition.raise_for_status()
     return add_condition.json()['data']['id']

--- a/src/ef_config.py
+++ b/src/ef_config.py
@@ -43,6 +43,7 @@ class EFConfig(object):
   SERVICE_GROUPS = set(_ef_site_config["SERVICE_GROUPS"])
   SPECIAL_VERSION_ENVS = _ef_site_config["SPECIAL_VERSION_ENVS"]
   VAGRANT_ENV = _ef_site_config["VAGRANT_ENV"]
+  PLUGINS = _ef_site_config["PLUGINS"]
 
   # Default service registry file name
   DEFAULT_SERVICE_REGISTRY_FILE = "service_registry.json"


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Read newrelic config info from the EFConfig object rather than a separate config file
## Linked PRs
https://github.com/crunchyroll/ellation_formation/pull/2813
https://github.com/EllationC/ellation-formation-c/pull/177
## Testing
```
± |master → update_ef_plugins {3} U:1 ?:1 ✗| → ef-generate staging --devel --commit
Not refreshing repo because --devel was set or running on Jenkins
env: staging
env_full: staging
env_short: staging
aws account profile: ellationeng
aws account number: 366843697376
check 1
staging
{'clients': {'iam': <botocore.client.IAM object at 0x1065d2950>, 'SESSION': Session(region_name='us-west-2'), 'kms': <botocore.client.KMS object at 0x10670f150>, 'ec2': <botocore.client.EC2 object at 0x10623ad90>, 'sts': <botocore.client.STS object at 0x106735ad0>}, 'context': <ef_context.EFContext object at 0x10401b190>, 'service': 'ef-generate', 'oInstance': <plugins.newrelic.executor.NewRelicAlerts object at 0x106945290>}
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): kms.us-west-2.amazonaws.com
4b3916af589b03d78aa5aabc06ec0c9e
check 2
check 3
check 4
check 5
<type 'dict'>
{'comparison': 'above', 'select_value': 'cpuPercent', 'critical_threshold': {'duration_minutes': 5, 'value': 90, 'time_function': 'all'}, 'enabled': True, 'filter': {'and': [{'is': {'ec2Tag_Name': 'staging-watchhistory.int'}}]}, 'event_type': 'SystemSample', 'policy_id': 130010, 'type': 'infra_metric', 'name': 'cpu_percent'}
{u'comparison': u'above', u'select_value': u'cpuPercent', u'created_at_epoch_millis': 1532468918610, u'name': u'cpu_percent', u'enabled': True, u'filter': {u'and': [{u'is': {u'ec2Tag_Name': u'staging-watchhistory.int'}}]}, u'updated_at_epoch_millis': 1532468918695, u'event_type': u'SystemSample', u'critical_threshold': {u'duration_minutes': 5, u'value': 90, u'time_function': u'all'}, u'type': u'infra_metric', u'id': 6266201, u'policy_id': 130010}
('comparison', 'above')
above
('select_value', 'cpuPercent')
cpuPercent
('critical_threshold', {'duration_minutes': 5, 'value': 90, 'time_function': 'all'})
{u'duration_minutes': 5, u'value': 90, u'time_function': u'all'}
('enabled', True)
True
('filter', {'and': [{'is': {'ec2Tag_Name': 'staging-watchhistory.int'}}]})
{u'and': [{u'is': {u'ec2Tag_Name': u'staging-watchhistory.int'}}]}
('event_type', 'SystemSample')
SystemSample
('policy_id', 130010)
130010
('type', 'infra_metric')
infra_metric
('name', 'cpu_percent')
cpu_percent
<type 'dict'>
{'comparison': 'above', 'select_value': 'provider.cpuUtilization.Average', 'critical_threshold': {'duration_minutes': 5, 'value': 90, 'time_function': 'all'}, 'integration_provider': 'RdsDbInstance', 'enabled': True, 'name': 'rds_cpu_percent', 'filter': {'and': [{'is': {'provider.dbInstanceIdentifier': 'staging-watchhistory.int'}}]}, 'policy_id': 130010, 'type': 'infra_metric', 'event_type': 'DatastoreSample'}
{u'comparison': u'above', u'select_value': u'provider.cpuUtilization.Average', u'created_at_epoch_millis': 1518141907414, u'name': u'rds_cpu_percent', u'integration_provider': u'RdsDbInstance', u'enabled': True, u'filter': {u'and': [{u'is': {u'provider.dbInstanceIdentifier': u'staging-watchhistory.int'}}]}, u'updated_at_epoch_millis': 1518141907506, u'event_type': u'DatastoreSample', u'critical_threshold': {u'duration_minutes': 5, u'value': 90, u'time_function': u'all'}, u'type': u'infra_metric', u'id': 849679, u'policy_id': 130010}
('comparison', 'above')
above
('select_value', 'provider.cpuUtilization.Average')
provider.cpuUtilization.Average
('critical_threshold', {'duration_minutes': 5, 'value': 90, 'time_function': 'all'})
{u'duration_minutes': 5, u'value': 90, u'time_function': u'all'}
('integration_provider', 'RdsDbInstance')
RdsDbInstance
('enabled', True)
True
('name', 'rds_cpu_percent')
rds_cpu_percent
('filter', {'and': [{'is': {'provider.dbInstanceIdentifier': 'staging-watchhistory.int'}}]})
{u'and': [{u'is': {u'provider.dbInstanceIdentifier': u'staging-watchhistory.int'}}]}
('policy_id', 130010)
130010
('type', 'infra_metric')
infra_metric
('event_type', 'DatastoreSample')
DatastoreSample
<type 'dict'>
{'comparison': 'above', 'select_value': 'diskUsedPercent', 'critical_threshold': {'duration_minutes': 5, 'value': 90, 'time_function': 'all'}, 'enabled': True, 'filter': {'and': [{'is': {'ec2Tag_Name': 'staging-watchhistory.int'}}]}, 'event_type': 'StorageSample', 'policy_id': 130010, 'type': 'infra_metric', 'name': 'disk_used'}
{u'comparison': u'above', u'select_value': u'diskUsedPercent', u'created_at_epoch_millis': 1509573182263, u'name': u'disk_used', u'enabled': True, u'filter': {u'and': [{u'is': {u'ec2Tag_Name': u'staging-watchhistory.int'}}]}, u'updated_at_epoch_millis': 1509573182296, u'event_type': u'StorageSample', u'critical_threshold': {u'duration_minutes': 5, u'value': 90, u'time_function': u'all'}, u'type': u'infra_metric', u'id': 601144, u'policy_id': 130010}
('comparison', 'above')
above
('select_value', 'diskUsedPercent')
diskUsedPercent
('critical_threshold', {'duration_minutes': 5, 'value': 90, 'time_function': 'all'})
{u'duration_minutes': 5, u'value': 90, u'time_function': u'all'}
('enabled', True)
True
('filter', {'and': [{'is': {'ec2Tag_Name': 'staging-watchhistory.int'}}]})
{u'and': [{u'is': {u'ec2Tag_Name': u'staging-watchhistory.int'}}]}
('event_type', 'StorageSample')
StorageSample
('policy_id', 130010)
130010
('type', 'infra_metric')
infra_metric
('name', 'disk_used')
```