### PR TITLE
Instantiate EFTemplateResolver only once, not for every file parameter

### DIFF
--- a/src/ef-instanceinit.py
+++ b/src/ef-instanceinit.py
@@ -82,17 +82,13 @@ def merge_files(service):
   """
   if WHERE == "ec2":
     config_reader = EFInstanceinitConfigReader("s3", service, log_info, RESOURCES["s3"])
+    resolver = EFTemplateResolver()
   elif WHERE == "virtualbox-kvm":
     config_path = "{}/{}".format(VIRTUALBOX_CONFIG_ROOT, service)
     config_reader = EFInstanceinitConfigReader("file", config_path, log_info)
+    resolver = EFTemplateResolver(env=EFConfig.VAGRANT_ENV, service=service)
 
   while config_reader.next():
-    # Make a new TemplateResolver for every file::parameters pair, so cached keys don't carry over
-    if WHERE == "ec2":
-      resolver = EFTemplateResolver()
-    elif WHERE == "virtualbox-kvm":
-      resolver = EFTemplateResolver(env=EFConfig.VAGRANT_ENV, service=service)
-
     log_info("checking: {}".format(config_reader.current_key))
 
     # if 'dest' for the current object contains an 'environments' list, check it


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Instantiate EFTemplateResolver only once, not for every file parameter. This is to avoid the problem for every single template and parameter pair to create an AWS boto3 client and avoid hitting the AWS rate limit for API calls. 

## Note
I have yet to understand what the comment means when it states `cached keys`. However from the initial testing, I have not seen a problem with moving this statement above and being reused for every parameter and template pair.

## Changelog
  * Instantiate EFTemplateResolver only once, not for every file parameter

## Testing
```
Loading parameters object: all/parameters/filebeat.yml.parameters.json
Resolving template
Loading template object: all/templates/filebeat.yml
Loading parameters object: all/parameters/filebeat.yml.parameters.json
make directories: /etc/filebeat 755
open: /etc/filebeat/filebeat.yml,w+
write
close
chmod file to: 644
chown last directory in path to: root:root
chown file to: root:root
next item: s3.ObjectSummary(bucket_name='ellation-cx-global-configs', key=u'all/templates/authorized_keys')
checking: all/templates/authorized_keys
Loading parameters object: all/parameters/authorized_keys.parameters.json
Resolving template
Loading template object: all/templates/authorized_keys
Loading parameters object: all/parameters/authorized_keys.parameters.json
make directories: /home/centos/.ssh 755
open: /home/centos/.ssh/authorized_keys,w+
write
close
chmod file to: 600
chown last directory in path to: centos:centos
chown file to: centos:centos
next item: s3.ObjectSummary(bucket_name='ellation-cx-global-configs', key=u'test-instance/templates/config.json')
checking: test-instance/templates/config.json
Loading parameters object: test-instance/parameters/config.json.parameters.json
Resolving template
Loading template object: test-instance/templates/config.json
Loading parameters object: test-instance/parameters/config.json.parameters.json
make directories: /srv/test-instance/src/config 755
open: /srv/test-instance/src/config/config.json,w+
write
close
chmod file to: 644
chown last directory in path to: root:root
chown file to: root:root
exit: success
```