### PR TITLE
Remove storing user defined symbols in class

### DIFF
--- a/src/ef_template_resolver.py
+++ b/src/ef_template_resolver.py
@@ -401,6 +401,8 @@ class EFTemplateResolver(object):
       - 4. built-in context (such as "ENV")
       - 5. parameters from a parameter file / dictionary of params
     """
+    # Ensure that our symbols are clean and are not from a previous template that was rendered
+    self.symbols = set()
     # Until all symbols are resolved or it is determined that some cannot be resolved, repeat:
     go_again = True
     while go_again:
@@ -424,6 +426,7 @@ class EFTemplateResolver(object):
         else:
           # 1. context - these are already in the resolved table
           # self.resolved[symbol] may have value=None; use has_key tell "resolved w/value=None" from "not resolved"
+          # these may be "global" symbols such like "ENV", "ACCOUNT", etc.
           if symbol in self.resolved:
             resolved_symbol = self.resolved[symbol]
           # 2. parameters
@@ -431,11 +434,10 @@ class EFTemplateResolver(object):
             resolved_symbol = self.search_parameters(symbol)
         # if symbol was resolved, replace it everywhere
         if resolved_symbol is not None:
-          self.resolved[symbol] = resolved_symbol
           if isinstance(resolved_symbol, list):
-            self.template = self.template.replace("{{" + symbol + "}}", "\n".join(self.resolved[symbol]))
+            self.template = self.template.replace("{{" + symbol + "}}", "\n".join(resolved_symbol))
           else:
-            self.template = self.template.replace("{{" + symbol + "}}", self.resolved[symbol])
+            self.template = self.template.replace("{{" + symbol + "}}", resolved_symbol)
           go_again = True
     return self.template
 


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Remove storing user defined symbols in class. What was defined before was that `self.symbols` and `self.resolved` were being reused upon each invocation of calling the `render()` function. This causes a problem where in ef-instanceinit.py would load all of the configurations (parameters and templates) for a particular service and store it into those two variables and will prevent key reuse across all files that are apart of that service.

## Changelog
  * Remove storing resolved symbols other than what is defined during class initialization to prevent key collision.
  * Reset `self.symbols` upon each invocation of calling `render()`

## Testing
```
000377-ml:ef-open jwong$ pytest tests/unit_tests/test_ef_*
===================================================================================================== test session starts =====================================================================================================
platform darwin -- Python 2.7.15, pytest-3.7.2, py-1.5.4, pluggy-0.7.1
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.5.1
collected 177 items

tests/unit_tests/test_ef_aws_resolver.py .........................................................                                                                                                                      [ 32%]
tests/unit_tests/test_ef_config.py .............                                                                                                                                                                        [ 39%]
tests/unit_tests/test_ef_config_resolver.py ....                                                                                                                                                                        [ 41%]
tests/unit_tests/test_ef_generate.py .........                                                                                                                                                                          [ 46%]
tests/unit_tests/test_ef_instanceinit_config_reader.py ..                                                                                                                                                               [ 48%]
tests/unit_tests/test_ef_password.py ............                                                                                                                                                                       [ 54%]
tests/unit_tests/test_ef_service_registry.py ........                                                                                                                                                                   [ 59%]
tests/unit_tests/test_ef_site_config.py .                                                                                                                                                                               [ 59%]
tests/unit_tests/test_ef_template_resolver.py ...........                                                                                                                                                               [ 66%]
tests/unit_tests/test_ef_utils.py ..........................................                                                                                                                                            [ 89%]
tests/unit_tests/test_ef_version.py .................                                                                                                                                                                   [ 99%]
tests/unit_tests/test_ef_version_resolver.py .                                                                                                                                                                          [100%]

================================================================================================= 177 passed in 0.93 seconds ==================================================================================================
000377-ml:ef-open jwong$
```