### PR TITLE
Compress Cloudformation template if it exceeds max allowed length

### DIFF
--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -34,6 +34,10 @@ from ef_service_registry import EFServiceRegistry
 from ef_template_resolver import EFTemplateResolver
 from ef_utils import create_aws_clients, fail, pull_repo
 
+# CONSTANTS
+# Cloudformation template size limit in bytes (which translates to the length of the template)
+CLOUDFORMATION_SIZE_LIMIT = 51200
+
 class EFCFContext(EFContext):
   def __init__(self):
     super(EFCFContext, self).__init__()
@@ -230,6 +234,14 @@ def main():
       fail("JSON error in parameter file: {}".format(parameter_file, error))
   else:
     parameters = []
+
+  # Detect if the template exceeds the maximum size that is allowed by Cloudformation
+  if len(template) > CLOUDFORMATION_SIZE_LIMIT:
+    # Compress the generated template by removing whitespaces
+    print("Template exceeds the max allowed length that Cloudformation will accept. Compressing template...")
+    print("Uncompressed size of template: {}".format(len(template)))
+    template = template.replace(" ", "")
+    print("Compressed size of template: {}".format(len(template)))
 
   # Validate rendered template before trying the stack operation
   if context.verbose:

--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -241,7 +241,7 @@ def main():
     print("Template exceeds the max allowed length that Cloudformation will accept. Compressing template...")
     print("Uncompressed size of template: {}".format(len(template)))
     unpacked = json.loads(template)
-    template = json.dumps(unpacked)
+    template = json.dumps(unpacked, separators=(",", ":"))
     print("Compressed size of template: {}".format(len(template)))
 
   # Validate rendered template before trying the stack operation

--- a/src/ef-cf.py
+++ b/src/ef-cf.py
@@ -240,7 +240,8 @@ def main():
     # Compress the generated template by removing whitespaces
     print("Template exceeds the max allowed length that Cloudformation will accept. Compressing template...")
     print("Uncompressed size of template: {}".format(len(template)))
-    template = template.replace(" ", "")
+    unpacked = json.loads(template)
+    template = json.dumps(unpacked)
     print("Compressed size of template: {}".format(len(template)))
 
   # Validate rendered template before trying the stack operation


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Compress Cloudformation template if it exceeds max allowed length.

Compression in this case is to remove whitespaces from the template. The original template remains intact and it is only the rendered template that will be sent to Cloudformation that is compressed. This is to avoid the scenario where our cloudformation template exceeds the length of max allowed template size to be sent over in the API request.

## Changelog
  * Remove whitespaces if the Cloudformation template exceeds the max allowed length / size of the template before sending it to Cloudformation.

## Testing
```
000377-ml:ellation_formation jwong$ ef-cf cloudformation/services/templates/subs.json proto0 --devel
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
not refreshing repo because --devel was set or running on Jenkins
Template exceeds the max allowed length that Cloudformation will accept. Compressing template...
Uncompressed size of template: 51607
Compressed size of template: 37287
Template passed validation
```