### PR TITLE
temporarily remove ef_plugin calls

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -29,7 +29,6 @@ import botocore.exceptions
 
 from ef_config import EFConfig
 from ef_context import EFContext
-from ef_plugin import run_plugins
 from ef_service_registry import EFServiceRegistry
 from ef_template_resolver import EFTemplateResolver
 from ef_utils import create_aws_clients, fail, pull_repo
@@ -298,7 +297,6 @@ def main():
             sys.exit(1)
           elif re.match(r".*_IN_PROGRESS(?!.)", stack_status) is not None:
             time.sleep(EFConfig.EF_CF_POLL_PERIOD)
-    run_plugins(context, clients)
   except botocore.exceptions.ClientError as error:
     if error.response["Error"]["Message"] in "No updates are to be performed.":
       # Don't fail when there is no update to the stack

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -40,7 +40,6 @@ from botocore.exceptions import ClientError
 from ef_aws_resolver import EFAwsResolver
 from ef_config import EFConfig
 from ef_context import EFContext
-from ef_plugin import run_plugins
 from ef_service_registry import EFServiceRegistry
 from ef_template_resolver import EFTemplateResolver
 from ef_utils import create_aws_clients, fail, get_account_id, http_get_metadata, pull_repo
@@ -574,9 +573,6 @@ def main():
     # 5. INLINE SERVICE'S POLICIES INTO ROLE
     # only eligible service types with "policies" sections in the service registry get policies
     conditionally_inline_policies(target_name, sr_entry)
-
-  # 5. Execute plugins
-  run_plugins(context_obj=CONTEXT, boto3_clients=CLIENTS)
 
   print("Exit: success")
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='ef-open',
-    version='0.1.2',
+    version='0.1.3',
     packages=['efopen'],
     install_requires=[
         "boto3",


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
This will temporarily remove calls to the ef_plugin module. This was specifically designed to work with our pants binaries and is no longer functioning since moving away from that pattern. Currently ef-cf and ef-generate can run into issues executing this.
## Changelog
- remove calls to run_plugins from ef-cf and ef-generate
## Testing
Before..
```
Traceback (most recent call last):
  File "/usr/local/bin/ef-cf", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/efopen/ef_cf.py", line 301, in main
    run_plugins(context, clients)
  File "/usr/local/lib/python2.7/site-packages/efopen/ef_plugin.py", line 85, in run_plugins
    plugin_module = importlib.import_module("plugins.{}.{}".format(plugin_name, modname))
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/Users/dlutsch/workspace/ellation_formation/plugins/newrelic/executor.py", line 4, in <module>
    from ef_config import EFConfig
ImportError: No module named ef_config
```
After...
```
=== CHANGESET ===
Creating changeset only. See AWS GUI for changeset
=== CHANGESET ===
Warning: Permanently added 'github.com,192.30.255.113' (RSA) to the list of known hosts.
Template exceeds the max allowed length that Cloudformation will accept. Compressing template...
Uncompressed size of template: 52039
Compressed size of template: 35955
Template passed validation
Creating changeset: prod-subs
```

