### PR TITLE
allow virt-what to fail during whereami(), and just return 'unknown' instead of excepting

### DIFF
--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -89,9 +89,12 @@ def whereami():
   except:
     pass
   # Virtualbox?
-  if isfile(__VIRT_WHAT) and access(__VIRT_WHAT, X_OK):
-    if subprocess.check_output(["sudo", __VIRT_WHAT]).split('\n')[0:2] == __VIRT_WHAT_VIRTUALBOX_WITH_KVM:
-      return "virtualbox-kvm"
+  try:
+    if isfile(__VIRT_WHAT) and access(__VIRT_WHAT, X_OK):
+      if subprocess.check_output(["sudo", __VIRT_WHAT]).split('\n')[0:2] == __VIRT_WHAT_VIRTUALBOX_WITH_KVM:
+        return "virtualbox-kvm"
+  except:
+    return "unknown"
   # Outside virtualbox/vagrant but not in aws; hostname is "<name>.local"
   hostname = gethostname()
   if re.findall(r"\.local$", hostname):


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
ef_utils.whereami() fails for not having sudo access in CI, when it's trying to call `virt-what` to determine whether it's running on a virtualbox machine.

Since this is not an important edge case, we just catch this exception scenario and return "unknown".

## Dependencies

## Linked PRs

## Testing
