### PR TITLE
Lookup ELBv2 dns-name and hosted-zone

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -312,6 +312,13 @@ class EFAwsResolver(object):
     else:
       return default
 
+  def elbv2_load_balancer(self, lookup):
+    client = EFAwsResolver.__CLIENTS['elbv2']
+    elbs = client.describe_load_balancers(Names=[lookup])
+    # getting the first one, since we requested only one lb
+    elb = elbs['LoadBalancers'][0]
+    return elb
+
   def elbv2_load_balancer_hosted_zone(self, lookup):
     """
     Args:
@@ -321,9 +328,7 @@ class EFAwsResolver(object):
       None if no match found
     """
     try:
-      client = EFAwsResolver.__CLIENTS['elbv2']
-      elbs = client.describe_load_balancers(Names=[lookup])
-      elb = elbs['LoadBalancers'][0]
+      elb = self.elbv2_load_balancer(lookup)
       return elb['CanonicalHostedZoneId']
     except ClientError:
       return None
@@ -337,9 +342,7 @@ class EFAwsResolver(object):
       None if no match found
     """
     try:
-      client = EFAwsResolver.__CLIENTS['elbv2']
-      elbs = client.describe_load_balancers(Names=[lookup])
-      elb = elbs['LoadBalancers'][0]
+      elb = self.elbv2_load_balancer(lookup)
       return elb['DNSName']
     except ClientError:
       return None

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -312,6 +312,23 @@ class EFAwsResolver(object):
     else:
       return default
 
+  def elbv2_load_balancer_hosted_zone(self, lookup):
+    """
+    Args:
+      lookup: the friendly name of the V2 elb to look up
+    Returns:
+      The hosted zone ID of the ELB found with a name matching 'lookup'.
+      None if no match found
+    """
+    try:
+      client = EFAwsResolver.__CLIENTS['elbv2']
+      elbs = client.describe_load_balancers(Names=[lookup])
+      elb = elbs['LoadBalancers'][0]
+      return elb['CanonicalHostedZoneId']
+    except ClientError:
+      return None
+
+
   def waf_rule_id(self, lookup, default=None):
     """
     Args:
@@ -572,6 +589,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_subnets(*kv[1:])
     elif kv[0] == "ec2:vpc/vpc-id":
       return self.ec2_vpc_vpc_id(*kv[1:])
+    elif kv[0] == "elbv2:load-balancer/hosted-zone":
+      return self.elbv2_load_balancer_hosted_zone(*kv[1:])
     elif kv[0] == "kms:decrypt":
       return self.kms_decrypt_value(*kv[1:])
     elif kv[0] == "kms:key_arn":

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -65,7 +65,7 @@ class EFAwsResolver(object):
     elb = elbs['LoadBalancers'][0]
     return elb
 
- a def acm_certificate_arn(self, lookup, default=None):
+  def acm_certificate_arn(self, lookup, default=None):
     """
     Args:
       lookup: region/domain on the certificate to be looked up

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -328,33 +328,33 @@ class EFAwsResolver(object):
     return elb
 
 
-  def elbv2_load_balancer_hosted_zone(self, lookup):
+  def elbv2_load_balancer_hosted_zone(self, lookup, default=None):
     """
     Args:
       lookup: the friendly name of the V2 elb to look up
+      default: value to return in case of no match
     Returns:
       The hosted zone ID of the ELB found with a name matching 'lookup'.
-      None if no match found
     """
     try:
       elb = self.elbv2_load_balancer(lookup)
       return elb['CanonicalHostedZoneId']
     except ClientError:
-      return None
+      return default
 
-  def elbv2_load_balancer_dns_name(self, lookup):
+  def elbv2_load_balancer_dns_name(self, lookup, default=None):
     """
     Args:
       lookup: the friendly name of the V2 elb to look up
+      default: value to return in case of no match
     Returns:
       The hosted zone ID of the ELB found with a name matching 'lookup'.
-      None if no match found
     """
     try:
       elb = self.elbv2_load_balancer(lookup)
       return elb['DNSName']
     except ClientError:
-      return None
+      return default
 
   def waf_rule_id(self, lookup, default=None):
     """

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -65,7 +65,7 @@ class EFAwsResolver(object):
     elb = elbs['LoadBalancers'][0]
     return elb
 
-  def acm_certificate_arn(self, lookup, default=None):
+ a def acm_certificate_arn(self, lookup, default=None):
     """
     Args:
       lookup: region/domain on the certificate to be looked up
@@ -350,7 +350,7 @@ class EFAwsResolver(object):
       The hosted zone ID of the ELB found with a name matching 'lookup'.
     """
     try:
-      elb = self.elbv2_load_balancer(lookup)
+      elb = self._elbv2_load_balancer(lookup)
       return elb['DNSName']
     except ClientError:
       return default

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -328,6 +328,21 @@ class EFAwsResolver(object):
     except ClientError:
       return None
 
+  def elbv2_load_balancer_dns_name(self, lookup):
+    """
+    Args:
+      lookup: the friendly name of the V2 elb to look up
+    Returns:
+      The hosted zone ID of the ELB found with a name matching 'lookup'.
+      None if no match found
+    """
+    try:
+      client = EFAwsResolver.__CLIENTS['elbv2']
+      elbs = client.describe_load_balancers(Names=[lookup])
+      elb = elbs['LoadBalancers'][0]
+      return elb['DNSName']
+    except ClientError:
+      return None
 
   def waf_rule_id(self, lookup, default=None):
     """
@@ -589,6 +604,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_subnets(*kv[1:])
     elif kv[0] == "ec2:vpc/vpc-id":
       return self.ec2_vpc_vpc_id(*kv[1:])
+    elif kv[0] == "elbv2:load-balancer/dns-name":
+      return self.elbv2_load_balancer_dns_name(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/hosted-zone":
       return self.elbv2_load_balancer_hosted_zone(*kv[1:])
     elif kv[0] == "kms:decrypt":

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -313,11 +313,20 @@ class EFAwsResolver(object):
       return default
 
   def elbv2_load_balancer(self, lookup):
+    """
+    Args:
+      lookup: the friendly name of the V2 elb to look up
+    Returns:
+      A dict with the load balancer description
+    Raises:
+      botocore.exceptions.ClientError: no such load-balancer
+    """
     client = EFAwsResolver.__CLIENTS['elbv2']
     elbs = client.describe_load_balancers(Names=[lookup])
     # getting the first one, since we requested only one lb
     elb = elbs['LoadBalancers'][0]
     return elb
+
 
   def elbv2_load_balancer_hosted_zone(self, lookup):
     """

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -235,10 +235,13 @@ class EFTemplateResolver(object):
         self.resolved["REGION"] = get_metadata_or_fail("placement/availability-zone/")[:-1]
 
       # Create clients - if accessing by role, profile should be None
+      clients = [
+         "cloudformation", "cloudfront", "ec2",
+         "elbv2", "iam", "kms", "lambda",
+         "route53", "s3", "sts", "waf",
+      ]
       try:
-        EFTemplateResolver.__CLIENTS = create_aws_clients(self.resolved["REGION"], profile,
-                                                          "cloudformation", "cloudfront", "ec2", "iam", "kms",
-                                                          "lambda", "route53", "s3", "sts", "waf")
+        EFTemplateResolver.__CLIENTS = create_aws_clients(self.resolved["REGION"], profile, *clients)
       except RuntimeError as error:
         fail("Exception logging in with Session()", error)
 

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -1970,3 +1970,23 @@ class TestEFAwsResolver(unittest.TestCase):
     self.assertEqual(
       ef_aws_resolver.lookup("elbv2:load-balancer/hosted-zone,%s" % lb_name),
       None)
+
+  def test_elbv2_load_balancer_dns_name(self):
+    """
+    Tests for ELBV2 DNS name lookup
+    """
+    hosted_zone = "ELBV2_hosted_zone"
+    dns_name = 'load-balancer.ellation.com'
+    lb_name = "env-balancer-name"
+    lb_description = {
+        u'LoadBalancers': [{
+            u'CanonicalHostedZoneId': hosted_zone,
+            u'DNSName': dns_name,
+            u'LoadBalancerName': lb_name,
+            }],
+        }
+    self._clients["elbv2"].describe_load_balancers.return_value = lb_description
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    self.assertEqual(
+      ef_aws_resolver.lookup("elbv2:load-balancer/dns-name,%s" % lb_name),
+      dns_name)

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -1950,9 +1950,9 @@ class TestEFAwsResolver(unittest.TestCase):
       ef_aws_resolver.lookup("elbv2:load-balancer/hosted-zone,%s" % lb_name),
       hosted_zone)
 
-  def test_elbv2_load_balancer_hosted_zone_no_such_elb(self):
+  def test_elbv2_load_balancer_no_such_elb(self):
     """
-    Tests for ELBv2 hosted zone lookup
+    Tests for fail in case of a missing ELBv2 attribute lookup
     """
     lb_name = "env-balancer-name"
     error = ClientError(
@@ -1966,10 +1966,14 @@ class TestEFAwsResolver(unittest.TestCase):
                 operation_name="DescribeLoadBalancers")
 
     self._clients["elbv2"].describe_load_balancers.side_effect = error
+
     ef_aws_resolver = EFAwsResolver(self._clients)
-    self.assertEqual(
-      ef_aws_resolver.lookup("elbv2:load-balancer/hosted-zone,%s" % lb_name),
-      None)
+    lookup_inputs = ["elbv2:load-balancer/hosted-zone,%s",
+                     "elbv2:load-balancer/dns-name,%s"]
+    for test in lookup_inputs:
+      self.assertEqual(
+        ef_aws_resolver.lookup(test % lb_name),
+        None)
 
   def test_elbv2_load_balancer_dns_name(self):
     """

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -47,6 +47,7 @@ class TestEFAwsResolver(unittest.TestCase):
     mock_waf_client = Mock(name="Mock WAF Client")
     mock_session = Mock(name="Mock Client")
     mock_kms_client = Mock(name="Mock KMS Client")
+    mock_elbv2_client = Mock(name="Mock ELBV2 Client")
 
     self._clients = {
       "cloudformation": mock_cloud_formation_client,
@@ -55,7 +56,8 @@ class TestEFAwsResolver(unittest.TestCase):
       "route53": mock_route_53_client,
       "waf": mock_waf_client,
       "SESSION": mock_session,
-      "kms": mock_kms_client
+      "kms": mock_kms_client,
+      "elbv2": mock_elbv2_client,
     }
 
   def tearDown(self):
@@ -1928,3 +1930,43 @@ class TestEFAwsResolver(unittest.TestCase):
     ef_aws_resolver = EFAwsResolver(self._clients)
     with self.assertRaises(RuntimeError):
       ef_aws_resolver.lookup("kms:key_arn,alias/key_no_exist")
+
+  def test_elbv2_load_balancer_hosted_zone(self):
+    """
+    Tests for ELBv2 hosted zone lookup
+    """
+    hosted_zone = "ELBV2_hosted_zone"
+    lb_name = "env-balancer-name"
+    lb_description = {
+        u'LoadBalancers': [{
+            u'CanonicalHostedZoneId': hosted_zone,
+            u'DNSName': 'load-balancer.ellation.com',
+            u'LoadBalancerName': lb_name,
+            }],
+        }
+    self._clients["elbv2"].describe_load_balancers.return_value = lb_description
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    self.assertEqual(
+      ef_aws_resolver.lookup("elbv2:load-balancer/hosted-zone,%s" % lb_name),
+      hosted_zone)
+
+  def test_elbv2_load_balancer_hosted_zone_no_such_elb(self):
+    """
+    Tests for ELBv2 hosted zone lookup
+    """
+    lb_name = "env-balancer-name"
+    error = ClientError(
+            error_response={
+                'Error': {'Code': 'LoadBalancerNotFound',
+                    'Message': "Load balancers '[%s]' not found" % lb_name,
+                    'Type': 'Sender'},
+                'HTTPStatusCode': 400,
+                'RequestId': 'ed43d22b-ddf9-11e8-a877-6f5e88f35437',
+                'RetryAttempts': 0},
+                operation_name="DescribeLoadBalancers")
+
+    self._clients["elbv2"].describe_load_balancers.side_effect = error
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    self.assertEqual(
+      ef_aws_resolver.lookup("elbv2:load-balancer/hosted-zone,%s" % lb_name),
+      None)

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -1968,12 +1968,27 @@ class TestEFAwsResolver(unittest.TestCase):
     self._clients["elbv2"].describe_load_balancers.side_effect = error
 
     ef_aws_resolver = EFAwsResolver(self._clients)
-    lookup_inputs = ["elbv2:load-balancer/hosted-zone,%s",
-                     "elbv2:load-balancer/dns-name,%s"]
-    for test in lookup_inputs:
-      self.assertEqual(
-        ef_aws_resolver.lookup(test % lb_name),
-        None)
+
+    lookup_input = "elbv2:load-balancer/hosted-zone,{}".format(lb_name)
+    self.assertEqual(
+      ef_aws_resolver.lookup(lookup_input),
+      None)
+
+    lookup_input = "elbv2:load-balancer/dns-name,{}".format(lb_name)
+    self.assertEqual(
+      ef_aws_resolver.lookup(lookup_input),
+      None)
+
+    default = "default_value"
+    lookup_input = "elbv2:load-balancer/hosted-zone,{},{}".format(lb_name, default)
+    self.assertEqual(
+      ef_aws_resolver.lookup(lookup_input),
+      default)
+
+    lookup_input = "elbv2:load-balancer/dns-name,{},{}".format(lb_name, default)
+    self.assertEqual(
+      ef_aws_resolver.lookup(lookup_input),
+      default)
 
   def test_elbv2_load_balancer_dns_name(self):
     """


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Add the ability to look up ELBv2 DNS and hosted zone properties.
[OPS-10777](https://ellation.atlassian.net/browse/OPS-10777)
## Changelog
- add elbv2 dns lookup
- add elbv2 hosted zone lookup
## Linked PRs
https://github.com/crunchyroll/ellation_formation/pull/3323
## Testing
`cd ellation_formation`
```
cat > reactions.json << h
           {
             "Name": "reactions.vrv.co",
             "Type": "A",
              "HostedZoneId": "{{aws:elbv2:load-balancer/hosted-zone,proto0-reactions-e}}",
              "DNSName": "{{aws:elbv2:load-balancer/dns-name,proto0-reactions-e}}"
             }
           },
           {
hh
```
`python ../ef-open/efopen/ef_cf.py reactions.json proto0 --devel --verbose`