### PR TITLE
remove bare exception catch

### DIFF
--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -144,11 +144,7 @@ def merge_files(context):
 
 def main():
   context = handle_args_and_set_context(sys.argv[1:])
-  try:
-    merge_files(context)
-  except Exception as e:
-    print("error {}".format(e))
-
+  merge_files(context)
 
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
remove bare exception catch that causes ef-resolve-config to always exit successfully
