### PR TITLE
OPS-10906-v2 respect default values for cognito lookups

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -600,7 +600,7 @@ class EFAwsResolver(object):
     """
     identity_pool_id = self.cognito_identity_identity_pool_id(lookup, default)
 
-    if not identity_pool_id:
+    if not identity_pool_id or identity_pool_id == default:
       return default
 
     # The ARN has to be constructed because there is no boto3 call that returns the full ARN for a cognito identity pool
@@ -645,7 +645,7 @@ class EFAwsResolver(object):
     """
     client = EFAwsResolver.__CLIENTS["cognito-idp"]
     user_pool_id = self.cognito_idp_user_pool_id(lookup, default)
-    if not user_pool_id:
+    if not user_pool_id or user_pool_id == default:
       return default
 
     response = client.describe_user_pool(UserPoolId=user_pool_id)


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
When the parent function calls the child function, and you specify a default value, say a String with a value "NONE", the child function would return that default value. The problem is, the parent function is only checking for None, when the NONE string is not a None type, so it takes that value thinking it's a valid value and looks it up and fails because AWS says WTF are you sending me.

So I've updated the parent function check so that it checks if the value is None or the same value as the default, meaning the lookup failed.
[OPS-10906](https://ellation.atlassian.net/browse/OPS-10906)

## Testing
Tested locally and in ellationeng
