### PR TITLE
Support creation of KMS keys for aws_fixtures

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -261,7 +261,7 @@ def main():
         StackName=stack_name,
         TemplateBody=template,
         Parameters=parameters,
-        Capabilities=['CAPABILITY_IAM'],
+        Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
         ChangeSetName=stack_name,
         ClientToken=stack_name
       )
@@ -272,7 +272,7 @@ def main():
           StackName=stack_name,
           TemplateBody=template,
           Parameters=parameters,
-          Capabilities=['CAPABILITY_IAM']
+          Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM']
         )
       else:
         print("Creating stack: {}".format(stack_name))
@@ -280,7 +280,7 @@ def main():
           StackName=stack_name,
           TemplateBody=template,
           Parameters=parameters,
-          Capabilities=['CAPABILITY_IAM']
+          Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM']
         )
       if context.poll_status:
         while True:

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -96,6 +96,7 @@ INSTANCE_PROFILE_SERVICE_TYPES = [
 # these service types get KMS Keys
 KMS_SERVICE_TYPES = [
   "aws_ec2",
+  "aws_fixture",
   "aws_lambda",
   "http_service"
 ]
@@ -412,55 +413,71 @@ def conditionally_create_kms_key(role_name, service_type):
     else:
       fail("Exception describing KMS key: {} {}".format(role_name, error))
 
-  formatted_principal = '"AWS": "arn:aws:iam::{}:role/{}"'.format(CONTEXT.account_id, role_name)
-  kms_key_policy = '''{
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Sid": "Enable IAM User Permissions",
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':root"
+  if service_type == "aws_fixture":
+    kms_key_policy = '''{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "Enable IAM User Permissions",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':root"
+          },
+          "Action": "kms:*",
+          "Resource": "*"
+        }
+      ]
+    }'''
+  else:
+    formatted_principal = '"AWS": "arn:aws:iam::{}:role/{}"'.format(CONTEXT.account_id, role_name)
+    kms_key_policy = '''{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "Enable IAM User Permissions",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':root"
+          },
+          "Action": "kms:*",
+          "Resource": "*"
         },
-        "Action": "kms:*",
-        "Resource": "*"
-      },
-      {
-        "Sid": "Allow Service Role Decrypt Privileges",
-        "Effect": "Allow",
-        "Principal": { ''' + formatted_principal + ''' },
-        "Action": "kms:Decrypt",
-        "Resource": "*"
-      },
-      {
-        "Sid": "Allow use of the key for default autoscaling group service role",
-        "Effect": "Allow",
-        "Principal": { "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" },
-        "Action": [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ],
-        "Resource": "*"
-      },
-      {
-        "Sid": "Allow attachment of persistent resourcesfor default autoscaling group service role",
-        "Effect": "Allow",
-        "Principal": { "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" },
-        "Action": [
-          "kms:CreateGrant"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "Bool": {
-            "kms:GrantIsForAWSResource": true
+        {
+          "Sid": "Allow Service Role Decrypt Privileges",
+          "Effect": "Allow",
+          "Principal": { ''' + formatted_principal + ''' },
+          "Action": "kms:Decrypt",
+          "Resource": "*"
+        },
+        {
+          "Sid": "Allow use of the key for default autoscaling group service role",
+          "Effect": "Allow",
+          "Principal": { "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" },
+          "Action": [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:DescribeKey"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Sid": "Allow attachment of persistent resourcesfor default autoscaling group service role",
+          "Effect": "Allow",
+          "Principal": { "AWS": "arn:aws:iam::''' + CONTEXT.account_id + ''':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" },
+          "Action": [
+            "kms:CreateGrant"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "Bool": {
+              "kms:GrantIsForAWSResource": true
+            }
           }
         }
-      }
-    ]
-  }'''
+      ]
+    }'''
 
   if not kms_key:
     print("Create KMS key: {}".format(key_alias))

--- a/tests/unit_tests/test_ef_generate.py
+++ b/tests/unit_tests/test_ef_generate.py
@@ -120,6 +120,19 @@ class TestEFGenerate(unittest.TestCase):
     self.mock_kms.create_key.assert_not_called()
     self.mock_kms.create_alias.assert_not_called()
 
+  def test_kms_service_type_fixture(self):
+    """
+    Verify that a KMS key is created when of service_type "aws_fixture"
+    """
+    self.service_type = "aws_fixture"
+    ef_generate.conditionally_create_kms_key(self.service_name, self.service_type)
+
+    self.mock_kms.create_key.assert_called()
+    self.mock_kms.create_alias.assert_called_with(
+      AliasName='alias/{}'.format(self.service_name),
+      TargetKeyId='1234'
+    )
+
   def test_not_kms_service_type(self):
     """
     Validates that a key/alias is not created for unsupported service types


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Support creation of KMS keys for aws_fixtures

## Changelog
  * Support creation of KMS keys for aws_fixtures
  * Add unit_tests for this feature

## Testing
```
Jerrys-Mac-mini:ellation_formation jwong$ pytest ~/workspace/ef-open/tests/unit_tests/test_ef_generate.py --cov ef_generate -v --cov-report term-missing
========================================================================================================================== test session starts ==========================================================================================================================
platform darwin -- Python 2.7.15, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.6.0
collected 10 items

../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_attach_managed_policies PASSED                                                                                                                                                              [ 10%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_create_kms_key PASSED                                                                                                                                                                       [ 20%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_create_kms_key_subservice PASSED                                                                                                                                                            [ 30%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_create_key_eventual_consistency_failure PASSED                                                                                                                                          [ 40%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_eventual_consistency_resilience PASSED                                                                                                                                                  [ 50%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_key_already_exists PASSED                                                                                                                                                               [ 60%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_service_type_fixture PASSED                                                                                                                                                             [ 70%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_no_aws_managed_policies_key_in_service PASSED                                                                                                                                               [ 80%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_not_kms_service_type PASSED                                                                                                                                                                 [ 90%]
../ef-open/tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_not_service_type_for_managed_policy PASSED                                                                                                                                                  [100%]
```

Functional test
```
Jerrys-Mac-mini:ellation-formation-rt-data jwong$ ef-password --length 32 data-dw prod
Generated Secret: <REDACTED>
{{aws:kms:decrypt,AQICAHh18fTbn0vnVua7B9scxIJd6MbF9xnyEw9fAGt80KfoLgG0W43U0iE5uJHRrIBd3NvdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMATgW6lBPtaIlzbbmAgEQgDs1t1/nP8RitCBAZVmQzu/CE/OWQy9nGpRr10JpKQ83V9bpk9n8a3VQ8Y1dpPY8y0l8mPq0z10HNV8J6g==}}

...
Jerrys-Mac-mini:ellation-formation-rt-data jwong$ ef-cf cloudformation/services/templates/data-dw.json prod --verbose
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
service_name: data-dw
env: prod
env_full: prod
env_short: prod
region: us-west-2
template_file: cloudformation/services/templates/data-dw.json
parameter_file: cloudformation/services/templates/../parameters/data-dw.parameters.prod.json
profile: ellation-rt-data
whereami: local
service type: aws_fixture
...
  {
    "ParameterKey": "MasterUserPasswordParam",
     "ParameterValue": "<REDACTED>" <-- This is the same as the above
  },
```