### PR TITLE
ignore security_group ref error

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -307,7 +307,7 @@ def main():
         mkdir(work_dir)
       with open(temp_file, 'w') as f:
         f.write(template)
-      cmd = 'cfn-lint {}'.format(temp_file)
+      cmd = 'cfn-lint --ignore-checks E2506 --template {}'.format(temp_file)
       p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
       stdout, stderr = p.communicate()
       print(stdout)

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -307,7 +307,7 @@ def main():
         mkdir(work_dir)
       with open(temp_file, 'w') as f:
         f.write(template)
-      cmd = 'cfn-lint --ignore-checks E2506 --template {}'.format(temp_file)
+      cmd = 'cfn-lint --debug --ignore-checks E2506 W3010 --template {}'.format(temp_file)
       p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
       stdout, stderr = p.communicate()
       print(stdout)


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Update ef-cf --lint to ignore cfn-lint error E2506 as it is incompatible with the way we reference security groups. Also W3010 as it is a false positive due to ef-open lookups. 
Details of the checks below:
```
E2506: Resource EC2 Security Group Ingress Properties
See if EC2 Security Group Ingress Properties are set correctly. Check that "SourceSecurityGroupId" or "SourceSecurityGroupName" are  are exclusive and using the type of Ref or GetAtt
```
```
W3010: Availability Zone Parameters should not be hardcoded
Check if an Availability Zone property is hardcoded.
```

## Changelog
update params to cfn-lint call
## Testing
`../ef-open/efopen/ef_cf.py cloudformation/services/templates/cr-web.json proto0 --devel --lint`