### PR TITLE
fix ef-password to pass tests.

### DIFF
--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -158,7 +158,7 @@ def handle_args_and_set_context(args):
   parser = argparse.ArgumentParser()
   parser.add_argument("service", help="name of service password is being generated for")
   parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
-  group = parser.add_mutually_exclusive_group(required=True)
+  group = parser.add_mutually_exclusive_group()
   group.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
   group.add_argument("--plaintext", help="secret to be encrypted rather than a randomly generated one", default="")
   group.add_argument("--secret_file", help="json file containing secrets to be encrypted", default="")

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -45,16 +45,32 @@ class TestEFPassword(unittest.TestCase):
     self.assertEqual(len(random_secret), 24)
     assert not set('[~!@#$%^&*()_+{}":;\']+$').intersection(random_secret)
 
-  def test_args(self):
-    """Test parsing args with all valid values"""
-    args = [self.service, self.env, "--length", "10", "--plaintext", "test", "--decrypt", "test", "--secret_file",
-            "test_data/parameters/test.cnf.parameters.json", "--match", "test"]
+  def test_args_decrypt(self):
+    """Test parsing args with all valid values (decrypt)"""
+    args = [self.service, self.env, "--length", "10", "--decrypt", "test"]
+    context = ef_password.handle_args_and_set_context(args)
+    self.assertEqual(context.env, self.env)
+    self.assertEqual(context.service, self.service)
+    self.assertEqual(context.length, 10)
+    self.assertEqual(context.decrypt, "test")
+
+  def test_args_plaintext(self):
+    """Test parsing args with all valid values (plaintext)"""
+    args = [self.service, self.env, "--length", "10", "--plaintext", "test"]
     context = ef_password.handle_args_and_set_context(args)
     self.assertEqual(context.env, self.env)
     self.assertEqual(context.service, self.service)
     self.assertEqual(context.length, 10)
     self.assertEqual(context.plaintext, "test")
-    self.assertEqual(context.decrypt, "test")
+
+  def test_args_secret_file(self):
+    """Test parsing args with all valid values (secret file)"""
+    args = [self.service, self.env, "--length", "10", "--secret_file",
+            "test_data/parameters/test.cnf.parameters.json", "--match", "test"]
+    context = ef_password.handle_args_and_set_context(args)
+    self.assertEqual(context.env, self.env)
+    self.assertEqual(context.service, self.service)
+    self.assertEqual(context.length, 10)
     self.assertEqual(context.secret_file, "test_data/parameters/test.cnf.parameters.json")
     self.assertEqual(context.match, "test")
 


### PR DESCRIPTION
## Ready State
**Ready**
 
fix ef-password to pass tests.

`ef-password --length 10` is technically valid, so making the excluseive set of --secret_file, --decrypt, and --plaintext be required was a bad assumption.
