### PR TITLE
Feature/ef diff detection

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -39,17 +39,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:61cc273d926d30ca047f1ae55ce0357f16f2726b0946f67a932bede88f9b086a",
-                "sha256:e9e93029b0d4f91ff342ffd953048c5a64e6a1522c2362c4521864bcc88cc365"
+                "sha256:1cea7879ac0905e598f8df9b0f1bd40405d571f06b206beb3215aa3b1034f5a2",
+                "sha256:86d82f24ef1193ae508ff8ec90d9e8b4b4c23578d10520682befa313175535ac"
             ],
-            "version": "==1.9.62"
+            "version": "==1.9.65"
         },
         "botocore": {
             "hashes": [
-                "sha256:1d1150e3ffd5e7a71f67b19c6a537bcd06d04ce5f1cd2bb0bb7b7801f20bb8fa",
-                "sha256:67ebafe2d0d6a37b62033bbc78786fdada02c38535f83d74313dc0dc281bf87d"
+                "sha256:a9e6b55fcb30a01ad5309912286f80c516aed6123b9ac5c8bfb0aeccd943650b",
+                "sha256:e969a68fc2bed981f3b6539cbb191f82b7034f95f04c664b06764446f22b9cee"
             ],
-            "version": "==1.12.62"
+            "version": "==1.12.65"
         },
         "certifi": {
             "hashes": [
@@ -71,6 +71,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
         },
         "configparser": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,7 +34,7 @@
                 "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
                 "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
             ],
-            "markers": "python_version == '2.7'",
+            "markers": "python_version < '3.4'",
             "version": "==1.5"
         },
         "boto3": {

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you have the ef-open installed and want to upgrade to the latest version you 
 
 # Use
 `ef-cf` - Evaluate templatized CloudFormation templates, with the option to generate changesets or apply them
+`ef-cf-diff` - Test some or all templates against a target environment, for differences
 `ef-check-config` - Validate the config files for JSON correctness
 `ef-generate` - Ensure the existence of various standard elements for a target environment
 `ef-instanceinit` - Host startup script which copies customized instance config from S3 to the local host

--- a/README.md
+++ b/README.md
@@ -18,16 +18,23 @@ If you have the ef-open installed and want to upgrade to the latest version you 
 
     $ pip install --upgrade ef-open
 
+# Use
+`ef-cf` - Evaluate templatized CloudFormation templates, with the option to generate changesets or apply them
+`ef-check-config` - Validate the config files for JSON correctness
+`ef-generate` - Ensure the existence of various standard elements for a target environment
+`ef-instanceinit` - Host startup script which copies customized instance config from S3 to the local host
+`ef-password` - Manage an encrypted secrets file, with the keys stored in AWS's KMS
+`ef-resolve-config` - Generate late-bind config assets, for testing
+`ef-version` - Manage versioned tagging for AMI's and static assets
 
 # Development
 ## Testing and Linting
-This project uses Python `unittest` framework for unit tests, and pylint for lint checking.
+This project uses Python `unittest` framework for unit tests, and `pylint` for lint checking.
 ```
 python setup.py test
 
 pylint --rcfile=./pylintrc ./efopen
 ```
-
 
 ## Versions
 This project uses [Versioneer](https://github.com/warner/python-versioneer) to manage the release versions, based on Git tags on the code repository.

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -259,7 +259,7 @@ def main():
   try:
     if context.changeset:
       print("Creating changeset: {}".format(stack_name))
-      clients["cloudformation"].create_change_set(
+      results = clients["cloudformation"].create_change_set(
         StackName=stack_name,
         TemplateBody=template,
         Parameters=parameters,
@@ -267,6 +267,9 @@ def main():
         ChangeSetName=stack_name,
         ClientToken=stack_name
       )
+      results_ids = {key: value for key, value in results.iteritems()
+                     if key in ('Id', 'StackId')}
+      print("Changeset Info: {}".format(json.dumps(results_ids)))
     elif context.commit:
       if stack_exists:
         print("Updating stack: {}".format(stack_name))

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -94,19 +94,19 @@ def handle_args_and_set_context(args):
   parser = argparse.ArgumentParser()
   parser.add_argument("template_file", help="/path/to/template_file.json")
   parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
+  parser.add_argument("--sr", help="optional /path/to/service_registry_file.json", default=None)
+  parser.add_argument("--verbose", help="Print additional info + resolved template", action="store_true", default=False)
+  parser.add_argument("--devel", help="Allow running from branch; don't refresh from origin", action="store_true",
+                      default=False)
   group = parser.add_mutually_exclusive_group()
   group.add_argument("--changeset", help="create a changeset; cannot be combined with --commit",
                       action="store_true", default=False)
   group.add_argument("--commit", help="Make changes in AWS (dry run if omitted); cannot be combined with --changeset",
                       action="store_true", default=False)
+  group.add_argument("--lint", help="Execute cfn-lint on the rendered template", action="store_true",
+                      default=False)
   parser.add_argument("--poll", help="Poll Cloudformation to check status of stack creation/updates",
                       action="store_true", default=False)
-  parser.add_argument("--sr", help="optional /path/to/service_registry_file.json", default=None)
-  parser.add_argument("--verbose", help="Print additional info + resolved template", action="store_true", default=False)
-  parser.add_argument("--devel", help="Allow running from branch; don't refresh from origin", action="store_true",
-                      default=False)
-  parser.add_argument("--lint", help="Execute cfn-lint on the rendered template", action="store_true",
-                      default=False)
   parsed_args = vars(parser.parse_args(args))
   context = EFCFContext()
   try:

--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -51,7 +51,7 @@ def changeset_is_empty(response):
 
 
 def wait_for_changeset_creation(cf_client, changeset_id, changeset_stackid):
-    remaining_tries = 3
+    remaining_tries = 30
     while remaining_tries > 0:
         remaining_tries -= 1
         res = cf_client.describe_change_set(ChangeSetName=changeset_id, StackName=changeset_stackid)

--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -24,9 +24,9 @@ import re
 import subprocess
 import sys
 import time
-from botocore.exceptions import ClientError
 
 import click
+from botocore.exceptions import ClientError
 
 from .ef_config import EFConfig
 from .ef_service_registry import EFServiceRegistry

--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -153,10 +153,6 @@ def evaluate_changesets(services, repo_root, include_env):
 
     for service_name, service in services.iteritems():
 
-        if '.' in service_name:
-            logger.debug("Service `%s` is a sub-service.  Skipping.", service_name)
-            continue
-
         for env_category in service['environments']:
             if env_category not in get_env_categories(include_env):
                 logger.debug('Skipping not-included environment `%s` for service `%s`',

--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -1,0 +1,24 @@
+"""
+Copyright 2016-2018 Ellation, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import click
+
+
+@click.command()
+def main():
+    pass

--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -16,9 +16,268 @@ limitations under the License.
 
 from __future__ import absolute_import, division, print_function
 
+import json
+import logging
+import os
+import os.path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
 import click
+
+from .ef_config import EFConfig
+from .ef_service_registry import EFServiceRegistry
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+ch = logging.StreamHandler(sys.stderr)
+ch.setLevel(logging.DEBUG)
+ch.setFormatter(logging.Formatter('%(levelname)s - %(message)s'))
+logger.addHandler(ch)
+
+ret_code = 0
+
+
+def test_template(file, env_name):
+    """
+    Evaluate the cfn-validate command, for the given file, and dump the output in the
+    given subdirectory.  Make the output directory if it doesn't exist.
+    """
+    logger.debug("Validating: `%s` in environment `%s`", file, env_name)
+
+    # cmd = 'cfn-lint {}'.format(file)
+    # p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # stdout, stderr = p.communicate()
+    # if p.returncode != 0:
+    #     global ret_code
+    #     ret_code = 1
+    # return stdout
+
+
+def test_for_cf_template_differences(template_dir):
+    """
+    Loop over all the generated templates in the given temporary directory,
+    and evaluate each template for differences agaist the target environment.
+    """
+    envdirs = os.listdir(template_dir)
+    for envdir in envdirs:
+        envdir_fullpath = os.path.join(template_dir, envdir)
+        template_files = os.listdir(envdir_fullpath)
+
+        for template_file in template_files:
+            template_file = os.path.join(envdir_fullpath, template_file)
+
+            test_template(template_file, envdir)
+
+
+def extract_template_from_efcf_output(raw_output):
+    """
+    The verbose output of ef-cf has some extra text before and after the
+    cloudformation template output.  Find just the template, and return that.
+    """
+    r = re.match(r".*(^{.*^}).*$", raw_output, re.MULTILINE | re.DOTALL)
+    return r.group(1)
+
+
+def generate_test_environment_name(env_name):
+    """
+    Some environments, like proto, need a numerical index, while others, like
+    prod do not.  Given an environment name from the service registry, return a
+    valid environment name in which to generate a template.
+    """
+    if env_name in ['alpha', 'proto']:
+        return '{}0'.format(env_name)
+    return env_name
+
+
+def render_templates(services, ef_root, target_dir, include_env):
+    """
+    Given a dict of services, use ef-cf to render the cloudformation
+    templates.  These can then be evaluated for correctness in a later step.
+
+    Sub-services (names with '.' in them) are skipped.
+    """
+    for service_name, service in services.iteritems():
+
+        if '.' in service_name:
+            logger.debug("Service `%s` is a sub-service.  Skipping.", service_name)
+            continue
+
+        for environment in service['environments']:
+            if environment not in include_env:
+                logger.debug('Skipping excluded environment `%s` for service `%s`',
+                             environment, service_name)
+                continue
+
+            output_dir = os.path.join(target_dir, environment)
+            logger.debug('Generating template for service `%s` in `%s`: `%s`',
+                         service_name, environment, output_dir)
+
+            # Set up the output directory for this service template
+            try:
+                os.mkdir(output_dir)
+            except OSError:
+                pass
+
+            gen_env = generate_test_environment_name(environment)
+
+            try:
+                cmd = 'cd {} && ef-cf {} {} --devel --verbose'.format(
+                      ef_root, service['template_file'], gen_env)
+
+                p = subprocess.Popen(cmd, shell=True,
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stdout, stderr = p.communicate()
+                if p.returncode != 0:
+                    raise Exception("Service: `{}`, Env: `{}`, Msg: `\n{}`".format(
+                                    service_name, gen_env, stderr))
+
+                out_filename = '{}.{}'.format(
+                    service_name,
+                    os.path.splitext(service['template_file'])[1][1:])
+                out_file = os.path.join(output_dir, out_filename)
+
+                tpl_content = extract_template_from_efcf_output(stdout)
+                with open(out_file, 'w') as f:
+                    f.write(tpl_content)
+
+            except Exception as e:
+                global ret_code
+                ret_code = 1
+                logger.error(e)
+
+
+def test_for_unused_template_files(template_files, services):
+    """
+    Loop over the template files, and print a warning for any that aren't
+    used by a service in the service registry
+    (the annoying sub-function is to deal with Python's lack of a labeled break)
+    """
+    def print_unused_template_warning(file, services):
+        for service_name, service in services.iteritems():
+            if service['template_file'] == file:
+                return
+        logger.warning("Template file has no service registry entry: `%s`", file)
+
+    for name, file in template_files.iteritems():
+        print_unused_template_warning(file, services)
+
+
+def get_matching_service_template_file(service_name, template_files):
+    """
+    Return the template file that goes with the given service name, or return
+    None if there's no match.  Subservices return the parent service's file.
+    """
+    # If this is a subservice, use the parent service's template
+    service_name = service_name.split('.')[0]
+    if service_name in template_files:
+        return template_files[service_name]
+    return None
+
+
+def get_dict_registry_services(registry, template_files, warn_missing_files=True):
+    """
+    Return a dict mapping service name to a dict containing the service's
+    type ('fixtures', 'platform_services', 'application_services', 'internal_services'),
+    the template file's absolute path, and a list of environments to which the
+    service is intended to deploy.
+
+    Service names that appear twice in the output list will emit a warning and
+    ignore the latter records.
+
+    Services which have no template file will not appear in the returned dict.
+    If the `warn_missing_files` boolean is True these files will emit a warning.
+    """
+    with open(registry) as fr:
+        parsed_registry = json.load(fr)
+
+    services = {}
+    for type in ['fixtures', 'platform_services', 'application_services', 'internal_services']:
+        for name, service in parsed_registry[type].iteritems():
+            if name in services:
+                logger.warning("Template name appears twice, ignoring later items: `%s`", name)
+                continue
+
+            template_file = get_matching_service_template_file(name, template_files)
+            if not template_file:
+                if warn_missing_files:
+                    logger.warning("No template file for `%s` (%s) `%s`", type, service['type'], name)
+                continue
+
+            services[name] = {
+                'type': type,
+                'template_file': template_file,
+                'environments': service['environments']
+            }
+
+    return services
+
+
+def scan_dir_for_template_files(search_dir):
+    """
+    Return a map of "likely service/template name" to "template file".
+    This includes all the template files in fixtures and in services.
+    """
+    template_files = {}
+    for type in ['fixtures', 'services']:
+        for x in os.listdir(os.path.join(search_dir, 'cloudformation', type, 'templates')):
+            name = os.path.splitext(x)[0]
+            template_files[name] = os.path.join(search_dir, 'cloudformation', type, 'templates', x)
+    return template_files
 
 
 @click.command()
-def main():
-    pass
+@click.option('--ef_root',
+              default="./",
+              required=False,
+              type=click.Path(exists=True, file_okay=False, dir_okay=True,
+                              readable=True, resolve_path=True),
+              help="The root directory of the ellation_formation git clone.")
+@click.option('--sr',
+              default=None,
+              required=False,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False,
+                              readable=True, resolve_path=True),
+              help="optional /path/to/service_registry_file.json")
+@click.option('--env', '-e',
+              multiple=True,
+              required=True,
+              type=click.Choice(EFConfig.ENV_LIST),
+              help="An environment to evaluate. Can be set several times.")
+@click.option('--template_file', '-t',
+              multiple=True,
+              required=False,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False,
+                              readable=True, resolve_path=True),
+              help="A specific template to process.  Can be passed multiple times.  If excluded, all templates will be run.")
+@click.version_option()
+def main(ef_root, sr, env, template_file):
+    service_registry = EFServiceRegistry(sr)
+
+    template_files = scan_dir_for_template_files(ef_root)
+
+    # If the list of whitelisted templates was passed, we're in "only render
+    # and test those templates" mode.  Otherwise we'll just do every template.
+    if template_file:
+        template_files = {name: file
+                          for name, file in template_files.iteritems()
+                          if file in template_file}
+
+    services = get_dict_registry_services(service_registry.filespec, template_files,
+                                          warn_missing_files=(not template_file))
+
+    test_for_unused_template_files(template_files, services)
+
+    template_gendir = tempfile.mkdtemp()
+
+    render_templates(services, ef_root, template_gendir, env)
+
+    test_for_cf_template_differences(template_gendir)
+
+    shutil.rmtree(template_gendir)
+
+    exit(ret_code)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from setuptools import setup
+
 import versioneer
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,26 +10,26 @@ def readme():
         return f.read()
 
 
-cfg = {
-    'name': 'ef-open',
-    'version': versioneer.get_version(),
-    'cmdclass': versioneer.get_cmdclass(),
-    'packages': [
+setup(
+    name='ef-open',
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    packages=[
         'efopen'
     ],
-    'install_requires': [
+    install_requires=[
         'boto3',
         'click',
         'PyYAML',
         'cfn-lint'
     ],
-    'extras_require': {
+    extras_require={
         'test': [
             'mock',
             'pylint',
         ]
     },
-    'entry_points': {
+    entry_points={
         'console_scripts': [
             'ef-cf=efopen.ef_cf:main',
             'ef-cf-diff=efopen.ef_cf_diff:main',
@@ -41,12 +41,10 @@ cfg = {
             'ef-version=efopen.ef_version:main'
         ],
     },
-    'url': 'https://github.com/crunchyroll/ef-open',
-    'license': "Apache License 2.0",
-    'author': 'Ellation, Inc.',
-    'author_email': 'ops@ellation.com',
-    'description': 'CloudFormation Tools by Ellation',
-    'long_description': readme()
-}
-
-setup(**cfg)
+    url='https://github.com/crunchyroll/ef-open',
+    license="Apache License 2.0",
+    author='Ellation, Inc.',
+    author_email='ops@ellation.com',
+    description='CloudFormation Tools by Ellation',
+    long_description=readme()
+)

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,37 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from setuptools import setup
 import versioneer
 
-setup(
-    name='ef-open',
-    version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
-    packages=[
+
+def readme():
+    with open('README.md') as f:
+        return f.read()
+
+
+cfg = {
+    'name': 'ef-open',
+    'version': versioneer.get_version(),
+    'cmdclass': versioneer.get_cmdclass(),
+    'packages': [
         'efopen'
     ],
-    install_requires=[
+    'install_requires': [
         'boto3',
+        'click',
         'PyYAML',
         'cfn-lint'
     ],
-    extras_require={
+    'extras_require': {
         'test': [
             'mock',
             'pylint',
         ]
     },
-    entry_points={
+    'entry_points': {
         'console_scripts': [
             'ef-cf=efopen.ef_cf:main',
+            'ef-cf-diff=efopen.ef_cf_diff:main',
             'ef-check-config=efopen.ef_check_config:main',
             'ef-generate=efopen.ef_generate:main',
             'ef-instanceinit=efopen.ef_instanceinit:main',
@@ -32,9 +40,12 @@ setup(
             'ef-version=efopen.ef_version:main'
         ],
     },
-    url='https://github.com/crunchyroll/ef-open',
-    license="Apache License 2.0",
-    author='Ellation, Inc.',
-    author_email='ops@ellation.com',
-    description='CloudFormation Tools by Ellation'
-)
+    'url': 'https://github.com/crunchyroll/ef-open',
+    'license': "Apache License 2.0",
+    'author': 'Ellation, Inc.',
+    'author_email': 'ops@ellation.com',
+    'description': 'CloudFormation Tools by Ellation',
+    'long_description': readme()
+}
+
+setup(**cfg)


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
In order to detect differences between what's committed to the cloud formation template repository and what's actually deployed, ef-cf-diff creates changesets for some or all templates and then tests them for emptiness.

```
$ ef-cf-diff --help
Usage: ef-cf-diff [OPTIONS]

Options:
  --repo_root DIRECTORY           The root directory of the template
                                  repository git clone.
  --sr FILE                       optional /path/to/service_registry_file.json
  -e, --env [some|set|of|package|names]
                                  An environment to evaluate. Can be set
                                  several times.  [required]
  -t, --template_file FILE        A specific template to process.  Can be
                                  passed multiple times.  If excluded, all
                                  templates will be run.
  --version                       Show the version and exit.
  --help                          Show this message and exit.```
