### PR TITLE
use profile on jenkins master

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -161,7 +161,10 @@ def main():
   # If running in EC2, use instance credentials (i.e. profile = None)
   # otherwise, use local credentials with profile name in .aws/credentials == account alias name
   if context.whereami == "ec2":
-    profile = None
+    if getenv("JENKINS_URL", False):
+      profile = context.account_alias
+    else:
+      profile = None
   else:
     profile = context.account_alias
 

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -160,11 +160,8 @@ def main():
 
   # If running in EC2, use instance credentials (i.e. profile = None)
   # otherwise, use local credentials with profile name in .aws/credentials == account alias name
-  if context.whereami == "ec2":
-    if getenv("JENKINS_URL", False):
-      profile = context.account_alias
-    else:
-      profile = None
+  if context.whereami == "ec2" and not getenv("JENKINS_URL", False):
+    profile = None
   else:
     profile = context.account_alias
 


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Allow jenkins master to use a profile when calling ef-cf
## Changelog
conditional around setting profile for boto3 session on ef-cf
## Testing
Faith
