### PR TITLE
Cf json linting

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -65,7 +65,7 @@ class EFCFContext(EFContext):
   @lint.setter
   def lint(self, value):
     if type(value) is not bool:
-      raise TypeError("changeset value must be bool")
+      raise TypeError("lint value must be bool")
     self._lint = value
 
   @property

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -313,6 +313,8 @@ def main():
     json.loads(template)  # Tests for valid JSON syntax, oddly not handled above
   except botocore.exceptions.ClientError as error:
     fail("Template did not pass validation", error)
+  except ValueError as e:  # includes simplejson.decoder.JSONDecodeError
+    fail('Failed to decode JSON', e)
 
   print("Template passed validation")
 

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -20,12 +20,11 @@ from __future__ import print_function
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 import time
-from os import getenv, mkdir, remove, rmdir
-from os.path import basename, dirname, exists, isfile, join, splitext
 
 import botocore.exceptions
 
@@ -43,6 +42,7 @@ class EFCFContext(EFContext):
   def __init__(self):
     super(EFCFContext, self).__init__()
     self._changeset = None
+    self._lint = None
     self._poll_status = None
     self._template_file = None
 
@@ -56,6 +56,17 @@ class EFCFContext(EFContext):
     if type(value) is not bool:
       raise TypeError("changeset value must be bool")
     self._changeset = value
+
+  @property
+  def lint(self):
+    """True if the tool should lint the rendered template rather than uploading to cloudformation"""
+    return self._lint
+
+  @lint.setter
+  def lint(self, value):
+    if type(value) is not bool:
+      raise TypeError("changeset value must be bool")
+    self._lint = value
 
   @property
   def poll_status(self):
@@ -126,7 +137,7 @@ def handle_args_and_set_context(args):
 
 def resolve_template(template, profile, env, region, service, verbose):
   # resolve {{SYMBOLS}} in the passed template file
-  isfile(template) or fail("Not a file: {}".format(template))
+  os.path.isfile(template) or fail("Not a file: {}".format(template))
   resolver = EFTemplateResolver(profile=profile, target_other=True, env=env,
                                 region=region, service=service, verbose=verbose)
   with open(template) as template_file:
@@ -144,14 +155,69 @@ def resolve_template(template, profile, env, region, service, verbose):
   else:
     return resolver.template
 
+
 def is_stack_termination_protected_env(env):
   return env in EFConfig.STACK_TERMINATION_PROTECTED_ENVS
+
 
 def enable_stack_termination_protection(clients, stack_name):
   clients["cloudformation"].update_termination_protection(
     EnableTerminationProtection=True,
     StackName=stack_name
   )
+
+
+class CFTemplateTests(object):
+
+  def __init__(self, template):
+    self.template = template
+    self.work_dir = os.path.join(os.path.dirname(__file__), '.lint')
+    self.local_template_path = os.path.join(self.work_dir, 'template.json')
+    self.jq_exit_code = None
+    self.cfn_exit_code = None
+    self.exit_code = None
+    self.standup()
+
+  def standup(self):
+    if not os.path.exists(self.work_dir):
+      os.mkdir(self.work_dir)
+
+    with open(self.local_template_path, 'w') as f:
+      f.write(self.template)
+
+  def run_tests(self):
+    self.json_lint()
+    self.cfn_lint()
+    self.teardown()
+
+  def json_lint(self):
+    print("=== JSON LINTING ===")
+    cmd = 'jq . {}'.format(self.local_template_path)
+    jq = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = jq.communicate()
+    print(stderr)
+    if jq.returncode == 0:
+      print("Template is valid JSON")
+    self.jq_exit_code = jq.returncode
+
+  def cfn_lint(self):
+    print("=== CLOUDFORMATION LINTING ===")
+    cmd = 'cfn-lint --ignore-checks E2506 W3010 --template {}'.format(self.local_template_path)
+    cfn = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = cfn.communicate()
+    print(stdout, stderr)
+    if cfn.returncode in [0, 4]:
+      print("Template passed CFN linting")
+    self.cfn_exit_code = cfn.returncode
+
+  def teardown(self):
+    os.remove(self.local_template_path)
+    os.rmdir(self.work_dir)
+    if self.jq_exit_code != 0 or self.cfn_exit_code not in [0, 4]:  # ignore cfn warnings
+      self.exit_code = 1
+    else:
+      self.exit_code = 0
+
 
 def main():
   context = handle_args_and_set_context(sys.argv[1:])
@@ -161,22 +227,22 @@ def main():
   elif not context.commit:
     print("=== DRY RUN ===\nValidation only. Use --commit to push template to CF\n=== DRY RUN ===")
 
-  service_name = basename(splitext(context.template_file)[0])
-  template_file_dir = dirname(context.template_file)
+  service_name = os.path.basename(os.path.splitext(context.template_file)[0])
+  template_file_dir = os.path.dirname(context.template_file)
   # parameter file may not exist, but compute the name it would have if it did
   parameter_file_dir = template_file_dir + "/../parameters"
   parameter_file = parameter_file_dir + "/" + service_name + ".parameters." + context.env_full + ".json"
 
   # If running in EC2, use instance credentials (i.e. profile = None)
   # otherwise, use local credentials with profile name in .aws/credentials == account alias name
-  if context.whereami == "ec2" and not getenv("JENKINS_URL", False):
+  if context.whereami == "ec2" and not os.getenv("JENKINS_URL", False):
     profile = None
   else:
     profile = context.account_alias
 
   # Get service registry and refresh repo if appropriate
   try:
-    if not (context.devel or getenv("JENKINS_URL", False)):
+    if not (context.devel or os.getenv("JENKINS_URL", False)):
       pull_repo()
     else:
       print("not refreshing repo because --devel was set or running on Jenkins")
@@ -229,7 +295,7 @@ def main():
     stack_exists = False
 
   # Load parameters from file
-  if isfile(parameter_file):
+  if os.path.isfile(parameter_file):
     parameters_template = resolve_template(
       template=parameter_file,
       profile=profile,
@@ -318,20 +384,10 @@ def main():
           elif re.match(r".*_IN_PROGRESS(?!.)", stack_status) is not None:
             time.sleep(EFConfig.EF_CF_POLL_PERIOD)
     elif context.lint:
-      print("=== LINTING ===")
-      work_dir = '.lint'
-      temp_file = join(work_dir, 'template.json')
-      if not exists(work_dir):
-        mkdir(work_dir)
-      with open(temp_file, 'w') as f:
-        f.write(template)
-      cmd = 'cfn-lint --debug --ignore-checks E2506 W3010 --template {}'.format(temp_file)
-      p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-      stdout, stderr = p.communicate()
-      print(stdout)
-      remove(temp_file)
-      rmdir(work_dir)
-      exit(p.returncode)
+      tester = CFTemplateTests(template)
+      tester.run_tests()
+      exit(tester.exit_code)
+
   except botocore.exceptions.ClientError as error:
     if error.response["Error"]["Message"] in "No updates are to be performed.":
       # Don't fail when there is no update to the stack

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -175,9 +175,9 @@ class CFTemplateLinter(object):
     self.local_template_path = os.path.join(self.work_dir, 'template.json')
     self.cfn_exit_code = None
     self.exit_code = None
-    self.standup()
+    self.setup()
 
-  def standup(self):
+  def setup(self):
     if not os.path.exists(self.work_dir):
       os.mkdir(self.work_dir)
 


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Adds json validation to rendered cf template, moves cfn-linting to it's own class, and undo's all the weird 'from os.foo import everything, and, the, kitchen, sink'
## Testing
Extra comma in template. 
Before:
```
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
Template passed validation
```

After:
```
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
Failed to decode JSON
ValueError('Expecting property name enclosed in double quotes: line 36 column 5 (char 923)',)
```

Remove extra comma and test lint command:
```
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
Template passed validation
=== CLOUDFORMATION LINTING ===
W2001 Parameter MonitoringIntervalParam not used.
../ef-open/efopen/.lint/template.json:29:5

W2001 Parameter MonitoringRoleArnParam not used.
../ef-open/efopen/.lint/template.json:33:5

W8001 Condition IsMultiZone not used
../ef-open/efopen/.lint/template.json:39:5

W8001 Condition EnvIsNotProd not used
../ef-open/efopen/.lint/template.json:45:5

W8001 Condition EnvIsProd not used
../ef-open/efopen/.lint/template.json:46:5

E3012 Property Resources/LaunchConfig/Properties/AssociatePublicIpAddress should be of type Boolean
../ef-open/efopen/.lint/template.json:59:9

E3012 Property Resources/ServerGroup/Properties/HealthCheckGracePeriod should be of type Integer
../ef-open/efopen/.lint/template.json:82:9

E3012 Property Resources/ServerGroup/Properties/Tags/0/PropagateAtLaunch should be of type Boolean
../ef-open/efopen/.lint/template.json:90:11

E3012 Property Resources/ExternalElasticLoadBalancer/Properties/CrossZone should be of type Boolean
../ef-open/efopen/.lint/template.json:111:9

E3012 Property Resources/ExternalElasticLoadBalancer/Properties/ConnectionSettings/IdleTimeout should be of type Integer
../ef-open/efopen/.lint/template.json:113:11

E3012 Property Resources/SgElbToEc2/Properties/FromPort should be of type Integer
../ef-open/efopen/.lint/template.json:154:9

E3012 Property Resources/SgElbToEc2/Properties/ToPort should be of type Integer
../ef-open/efopen/.lint/template.json:155:9
```

