### PR TITLE
add --lint param to ef-resolve-config

### DIFF
--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -136,7 +136,7 @@ def merge_files(context):
     except ValueError as e:
       fail("Failed to decode JSON", e)
   elif context.lint and context.template_path.endswith((".yml", ".yaml")):
-    cmd = 'yamllint -d relaxed {}'.format(context.template_path)
+    cmd = "yamllint -d relaxed {}".format(context.template_path)
     yamllint = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = yamllint.communicate()
     print(stdout, stderr)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         'boto3',
         'click',
         'PyYAML',
-        'cfn-lint'
+        'cfn-lint',
+        'yamllint'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Using `ef-resolve-config --lint` will perform linting if the template is a json or yaml. 
## Changelog
- add lint param and behavior
- fix import order
## Testing
_Intentionally broken yaml:_
```
± |master {13} S:1 U:1 ✗| → ../ef-open/efopen/ef_resolve_config.py proto0 configs/cr-manga.cron/templates/cr-manga_config.yml --lint
/Users/dlutsch/workspace/ellation_formation/configs/cr-manga.cron/templates/cr-manga_config.yml
  1:2       warning  wrong indentation: expected 0 but found 1  (indentation)
  6:20      warning  too many spaces after colon  (colons)
  7:20      warning  too many spaces after colon  (colons)
  8:20      warning  too many spaces after colon  (colons)
  9:1       error    trailing spaces  (trailing-spaces)


YAML failed linting process
```

_Intentionally broken JSON:_
```
± |master {13} S:1 ✗| → ../ef-open/efopen/ef_resolve_config.py proto0 configs/cst/templates/config.json --lint
Failed to decode JSON
ValueError('Expecting property name: line 11 column 3 (char 404)',)
```
