### PR TITLE
allow placeholder string for failed ami lookups

### DIFF
--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -437,7 +437,7 @@ class EFTemplateResolver(object):
         elif symbol[:8] == "version:":
           resolved_symbol = EFTemplateResolver.__VR.lookup(symbol[8:])
           if not resolved_symbol:
-            print("WARNING: No ami-id found for {{%s}} - placeholder value of 'NONE' used in rendered template" % symbol)
+            print("WARNING: Lookup failed for {{%s}} - placeholder value of 'NONE' used in rendered template" % symbol)
             resolved_symbol = "NONE"
         else:
           # 1. context - these are already in the resolved table

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -436,6 +436,9 @@ class EFTemplateResolver(object):
           resolved_symbol = EFTemplateResolver.__EFCR.lookup(symbol[9:])
         elif symbol[:8] == "version:":
           resolved_symbol = EFTemplateResolver.__VR.lookup(symbol[8:])
+          if not resolved_symbol:
+            print("WARNING: No ami-id found for {{%s}} - placeholder value of 'NONE' used in rendered template" % symbol)
+            resolved_symbol = "NONE"
         else:
           # 1. context - these are already in the resolved table
           # self.resolved[symbol] may have value=None; use has_key tell "resolved w/value=None" from "not resolved"


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Inserts a placeholder value of "NONE" for templates where an ami-id lookup has failed. Specifically used for a service that hasn't yet been deployed. Once the template successfully renders we can then run testing against it for CI. 
## Testing
```
± |test_ef_ci_updates_4 {13} ✓| → ../ef-open/efopen/ef_cf.py cloudformation/services/templates/categories.json prod --devel --lint
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
not refreshing repo because --devel was set or running on Jenkins
WARNING: No ami-id found for {{version:ami-id,prod/categories}} - placeholder value of 'NONE' used in rendered template
Template passed validation
```

