### PR TITLE
ef-cf --percent feature

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -169,12 +169,9 @@ def enable_stack_termination_protection(clients, stack_name):
     StackName=stack_name
   )
 
-def calculate_min_instances_in_service(autoscaling_group, percent):
-  print(autoscaling_group)
-
 def calculate_max_batch_size(clients, service, percent):
-  response = clients["autoscaling"].describe_auto_scaling_groups(AutoScalingGroupNames=[service])
-
+  autoscaling_group_properties = get_autoscaling_group_properties(clients, service.split("-")[0], service.split("-")[1])
+  print(autoscaling_group_properties)
 
 class CFTemplateLinter(object):
 
@@ -343,7 +340,6 @@ def main():
           autoscaling_group = modify_template["Resources"][key]["Properties"]
           service = autoscaling_group["Tags"][0]["Value"]
           autoscaling_group_properties = get_autoscaling_group_properties(clients, service.split("-")[0], service.split("-")[1])
-          new_min_instance_in_service = calculate_min_instances_in_service(autoscaling_group_properties, context.percent)
           new_max_batch_size = calculate_max_batch_size(clients, service, context.percent)
 
 

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -117,7 +117,7 @@ def handle_args_and_set_context(args):
                       action="store_true", default=False)
   group.add_argument("--lint", help="Execute cfn-lint on the rendered template", action="store_true",
                       default=False)
-  parser.add_argument("--percent", help="Specifies an override to the percentage of instances in an Auto Scaling rolling update",
+  parser.add_argument("--percent", help="Specifies an override to the percentage of instances in an Auto Scaling rolling update (e.g. 10 for 10%%)",
                       type=int, default=False)
   parser.add_argument("--poll", help="Poll Cloudformation to check status of stack creation/updates",
                       action="store_true", default=False)
@@ -256,7 +256,7 @@ def main():
          .format(context.env_full, service_name, ", ".join(context.service_registry.valid_envs(service_name))))
 
   if context.percent and (context.percent <= 0 or context.percent > 100):
-    fail("Percent value cannot be less than 0 and greater than 100")
+    fail("Percent value cannot be less than or equal to 0 and greater than 100")
 
   # Set the region found in the service_registry. Default is EFConfig.DEFAULT_REGION if region key not found
   region = context.service_registry.service_region(service_name)

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -255,6 +255,9 @@ def main():
     fail("Invalid environment: {} for service_name: {}\nValid environments are: {}" \
          .format(context.env_full, service_name, ", ".join(context.service_registry.valid_envs(service_name))))
 
+  if context.percent <= 0 or context.percent > 100:
+    fail("Percent value cannot be less than 0 and greater than 100")
+
   # Set the region found in the service_registry. Default is EFConfig.DEFAULT_REGION if region key not found
   region = context.service_registry.service_region(service_name)
 

--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -116,6 +116,8 @@ def handle_args_and_set_context(args):
                       action="store_true", default=False)
   group.add_argument("--lint", help="Execute cfn-lint on the rendered template", action="store_true",
                       default=False)
+  parser.add_argument("--percent", help="Specifies an override to the percentage of instances in an Auto Scaling rolling update",
+                      type=int, default=False)
   parser.add_argument("--poll", help="Poll Cloudformation to check status of stack creation/updates",
                       action="store_true", default=False)
   parsed_args = vars(parser.parse_args(args))
@@ -129,6 +131,7 @@ def handle_args_and_set_context(args):
   context.commit = parsed_args["commit"]
   context.devel = parsed_args["devel"]
   context.lint = parsed_args["lint"]
+  context.percent = parsed_args["percent"]
   context.poll_status = parsed_args["poll"]
   context.verbose = parsed_args["verbose"]
   # Set up service registry and policy template path which depends on it
@@ -321,6 +324,10 @@ def main():
     fail('Failed to decode JSON', e)
 
   print("Template passed validation")
+  
+  if context.percent:
+    print("Modifying deploy rate to {}%".format(context.percent))
+
 
   # DO IT
   try:

--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -415,3 +415,35 @@ def get_template_parameters_s3(template_key, s3_resource):
     except ClientError:
       continue
   return None
+
+def get_autoscaling_group_properties(clients, env, service):
+  """
+  Gets the autoscaling group properties based on the service name that is provided. This function will attempt the find
+  the autoscaling group base on the following logic:
+    1. If the service name provided matches the autoscaling group name
+    2. If the service name provided matches the Name tag of the autoscaling group
+    3. If the service name provided does not match the above, return None
+  Args:
+    clients: Instantiated boto3 autoscaling client
+    env: Name of the environment to search for the autoscaling group
+    service: Name of the service
+  Returns:
+    JSON object of the autoscaling group properties if it exists
+  """
+  try:
+    # See if {{ENV}}-{{SERVICE}} matches ASG name
+    response = clients["autoscaling"].describe_auto_scaling_groups(AutoScalingGroupNames=["{}-{}".format(env, service)])
+    if len(response["AutoScalingGroups"]) == 0:
+      # See if {{ENV}}-{{SERVICE}} matches ASG tag name
+      response = clients["autoscaling"].describe_tags(Filters=[{ "Name": "Key", "Values": ["Name"] }, { "Name": "Value", "Values": ["{}-{}".format(env, service)]}])
+      if len(response["Tags"]) == 0:
+        # Query does not match either of the above, return None
+        return None
+      else:
+         asg_name = response["Tags"][0]["ResourceId"]
+         response = clients["autoscaling"].describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+         return response["AutoScalingGroups"]
+    else:
+      return response["AutoScalingGroups"]
+  except ClientError as error:
+    raise RuntimeError("Error in finding autoscaling group {} {}".format(env, service), error)

--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -416,7 +416,7 @@ def get_template_parameters_s3(template_key, s3_resource):
       continue
   return None
 
-def get_autoscaling_group_properties(clients, env, service):
+def get_autoscaling_group_properties(asg_client, env, service):
   """
   Gets the autoscaling group properties based on the service name that is provided. This function will attempt the find
   the autoscaling group base on the following logic:
@@ -432,16 +432,16 @@ def get_autoscaling_group_properties(clients, env, service):
   """
   try:
     # See if {{ENV}}-{{SERVICE}} matches ASG name
-    response = clients["autoscaling"].describe_auto_scaling_groups(AutoScalingGroupNames=["{}-{}".format(env, service)])
+    response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=["{}-{}".format(env, service)])
     if len(response["AutoScalingGroups"]) == 0:
       # See if {{ENV}}-{{SERVICE}} matches ASG tag name
-      response = clients["autoscaling"].describe_tags(Filters=[{ "Name": "Key", "Values": ["Name"] }, { "Name": "Value", "Values": ["{}-{}".format(env, service)]}])
+      response = asg_client.describe_tags(Filters=[{ "Name": "Key", "Values": ["Name"] }, { "Name": "Value", "Values": ["{}-{}".format(env, service)]}])
       if len(response["Tags"]) == 0:
         # Query does not match either of the above, return None
         return None
       else:
          asg_name = response["Tags"][0]["ResourceId"]
-         response = clients["autoscaling"].describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+         response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
          return response["AutoScalingGroups"]
     else:
       return response["AutoScalingGroups"]


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
ef-cf --percent feature

Add the ability to tweak the max batch size of a particular cloudformation template to speed up (or down) the deployments of a particular service.

## Changelog
  * ef-cf --percent feature
  * Unit test for new helper function

## Testing
```
Jerrys-Mac-mini:ef-open jwong$ pytest tests/unit_tests/test_ef_utils.py --cov ef_utils -v --cov-report term-missing --disable-pytest-warnings
========================================================================================================================== test session starts ==========================================================================================================================
platform darwin -- Python 2.7.15, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.6.0
collected 45 items

tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients PASSED                                                                                                                                                                                    [  2%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_cache_multiple_configs PASSED                                                                                                                                                             [  4%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_cache_new_clients PASSED                                                                                                                                                                  [  6%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_cache_same_client PASSED                                                                                                                                                                  [  8%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_no_profile PASSED                                                                                                                                                                         [ 11%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_env_valid PASSED                                                                                                                                                                                             [ 13%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_env_valid_invalid_envs PASSED                                                                                                                                                                                [ 15%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_None_message PASSED                                                                                                                                                                                [ 17%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_empty_string PASSED                                                                                                                                                                                [ 20%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_message PASSED                                                                                                                                                                                     [ 22%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_message_and_exception_data PASSED                                                                                                                                                                  [ 24%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_account_alias PASSED                                                                                                                                                                                     [ 26%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_account_alias_invalid_env PASSED                                                                                                                                                                         [ 28%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_account_id PASSED                                                                                                                                                                                        [ 31%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_autoscaling_group_properties_valid_asg_name PASSED                                                                                                                                                       [ 33%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_autoscaling_group_properties_valid_tag_name PASSED                                                                                                                                                       [ 35%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_env_short PASSED                                                                                                                                                                                         [ 37%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_env_short_invalid_envs PASSED                                                                                                                                                                            [ 40%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context PASSED                                                                                                                                                                              [ 42%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context_ec2_invalid_environment_exception PASSED                                                                                                                                            [ 44%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context_metadata_exception PASSED                                                                                                                                                           [ 46%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_template_parameters_file PASSED                                                                                                                                                                          [ 48%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_template_parameters_s3 PASSED                                                                                                                                                                            [ 51%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_global_env_valid PASSED                                                                                                                                                                                      [ 53%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_global_env_valid_non_scoped_envs PASSED                                                                                                                                                                      [ 55%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_env PASSED                                                                                                                                                                                 [ 57%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_env_exception PASSED                                                                                                                                                                       [ 60%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_role PASSED                                                                                                                                                                                [ 62%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_role_exception PASSED                                                                                                                                                                      [ 64%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_metadata_200_status_code PASSED                                                                                                                                                                     [ 66%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_metadata_non_200_status_code PASSED                                                                                                                                                                 [ 68%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_https_credentials PASSED                                                                                                                                                                           [ 71%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_incorrect_branch PASSED                                                                                                                                                                            [ 73%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_incorrect_repo PASSED                                                                                                                                                                              [ 75%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_pull_repo_ssh_credentials PASSED                                                                                                                                                                             [ 77%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_ec2 PASSED                                                                                                                                                                                          [ 80%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_local PASSED                                                                                                                                                                                        [ 82%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_unknown PASSED                                                                                                                                                                                      [ 84%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_call PASSED                                                                                                                                                                                   [ 86%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_client_error PASSED                                                                                                                                                                     [ 88%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_without_b64_secret PASSED                                                                                                                                                               [ 91%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call PASSED                                                                                                                                                                                   [ 93%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call_subservice PASSED                                                                                                                                                                        [ 95%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_fails_client_error PASSED                                                                                                                                                                     [ 97%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_returns_b64 PASSED                                                                                                                                                                            [100%]

---------- coverage: platform darwin, python 2.7.15-final-0 ----------
Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
efopen/ef_utils.py     212     45    79%   73, 81-86, 103-104, 109-111, 159-160, 181-182, 188-189, 194-195, 235-236, 251-252, 279, 310, 335, 356-363, 376-382, 397-398, 417, 441, 448-449


================================================================================================================ 45 passed, 24 warnings in 0.31 seconds =================================================================================================================
Jerrys-Mac-mini:ef-open jwong$
```

![screen shot 2019-01-23 at 4 48 48 pm](https://user-images.githubusercontent.com/712024/51714472-2ed48a00-1fea-11e9-894a-408e917a1b6f.png)
![screen shot 2019-01-23 at 4 48 42 pm](https://user-images.githubusercontent.com/712024/51714473-2ed48a00-1fea-11e9-9566-c5aa08b6393f.png)
![screen shot 2019-01-23 at 4 48 29 pm](https://user-images.githubusercontent.com/712024/51714474-2ed48a00-1fea-11e9-8f47-7519dd7e39e7.png)
