### PR TITLE
Lint resolved configs

### DIFF
--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -31,6 +31,8 @@ import sys
 from os.path import abspath, dirname, normpath
 
 import yaml
+from yamllint import linter as yamllinter
+from yamllint import config as yamllint_config
 
 import ef_utils
 from ef_config import EFConfig
@@ -141,11 +143,10 @@ def merge_files(context):
       except ValueError as e:
         fail("JSON failed linting process.", e)
     elif context.template_path.endswith((".yml", ".yaml")):
-      cmd = "yamllint -d relaxed {}".format(context.template_path)
-      yamllint = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-      stdout, stderr = yamllint.communicate()
-      print(stdout, stderr)
-      if yamllint.returncode != 0:
+      conf = yamllint_config.YamlLintConfig(content='extends: relaxed')
+      lint_errors = list(yamllinter.run(rendered_body, conf))
+      if lint_errors:
+        print("\n".join(map(str, lint_errors)))
         fail("YAML failed linting process.")
       else:
         print("YAML passed linting process.")

--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -154,10 +154,6 @@ def merge_files(context):
           # printing line - 1 because lists start at 0, but files at 1
           print("\t", split_body[error.line - 1])
         fail("YAML failed linting process.")
-      else:
-        print("YAML passed linting process.")
-    else:
-      print("Template is not a yaml or json, skipping lint.")
 
   if context.verbose:
     print(context)
@@ -176,7 +172,6 @@ def merge_files(context):
   elif context.silent:
     print("Config template rendered successfully.")
   else:
-    print("Config template rendered successfully.")
     print(rendered_body)
 
 

--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -144,7 +144,9 @@ def merge_files(context):
         fail("JSON failed linting process.", e)
     elif context.template_path.endswith((".yml", ".yaml")):
       conf = yamllint_config.YamlLintConfig(content='extends: relaxed')
-      lint_errors = list(yamllinter.run(rendered_body, conf))
+      lint_output = yamllinter.run(rendered_body, conf)
+      lint_level = 'error'
+      lint_errors = [issue for issue in lint_output if issue.level == lint_level]
       if lint_errors:
         print("\n".join(map(str, lint_errors)))
         fail("YAML failed linting process.")

--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -148,7 +148,11 @@ def merge_files(context):
       lint_level = 'error'
       lint_errors = [issue for issue in lint_output if issue.level == lint_level]
       if lint_errors:
-        print("\n".join(map(str, lint_errors)))
+        split_body = rendered_body.splitlines()
+        for error in lint_errors:
+          print(error)
+          # printing line - 1 because lists start at 0, but files at 1
+          print("\t", split_body[error.line - 1])
         fail("YAML failed linting process.")
       else:
         print("YAML passed linting process.")


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Currently, we're linting yaml files before resolving their ef-open values. This leads to false positives, potential misses (in case the resolved variables are not yaml compliant) and developer workarounds.

Also, the PR remove success messages, allowing for piping or redirecting the output in order to obtain a valid config file; e.g `ef-resolve-config prod template.yml > config.yml`
## Changelog
- lint resolved yamls
- print lines that failed linting
- if not `--silent`, print only the template without success messages