### PR TITLE
remove inline ignore_checks, move to config file

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -190,7 +190,7 @@ class CFTemplateLinter(object):
 
   def cfn_lint(self):
     print("=== CLOUDFORMATION LINTING ===")
-    cmd = 'cfn-lint --ignore-checks E2506 W3010 --template {}'.format(self.local_template_path)
+    cmd = 'cfn-lint --template {}'.format(self.local_template_path)
     cfn = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = cfn.communicate()
     print(stdout, stderr)


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Removes hardcoded ignore-checks from the cfn-lint command call. Instead these will be defined in a .cfnlintrc file in the dir that ef-cf is being run in. 
See: https://github.com/awslabs/cfn-python-lint#config-file