### PR TITLE
upgrade dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -39,17 +39,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0e25dd84d0e97c32200103588b8e935c8fba887b96beb955b222be5ddf380cd4",
-                "sha256:3539636d0c883b9dfc0188bec3a1016cb6da1cdf3d4a4d77b54260b10a8d6e65"
+                "sha256:63cd957ba663f5c10ff48ed904575eaa701314f79f18dbc59bd050311cd5f809",
+                "sha256:d1338582bc58741f54bd6b43488de6097a82ea45cebed0a3fd936981eadbb3a5"
             ],
-            "version": "==1.9.77"
+            "version": "==1.9.86"
         },
         "botocore": {
             "hashes": [
-                "sha256:0fea3d60ed866cb622b34c2b1bff0e7b9ebcde6be5e0f6769f354f2ed5c9a602",
-                "sha256:e1c9dfbf52e430b2cce7a90b539f97cf4587dffeff535c243c42d97323fa1bdc"
+                "sha256:24444e7580f0114c3e9fff5d2032c6f0cfbf88691b1be3ba27c6922507a902ec",
+                "sha256:5b01a16f02c3da55068b3aacfa1c37dd8e17141551e1702424b38dd21fa1c792"
             ],
-            "version": "==1.12.77"
+            "version": "==1.12.86"
         },
         "certifi": {
             "hashes": [
@@ -60,10 +60,10 @@
         },
         "cfn-lint": {
             "hashes": [
-                "sha256:7c3565b2da47b90993c9c8963c6d6ae182174d725c1041f5f1d8e6a3295b4f70",
-                "sha256:e0b51ada41bfa57b1d102cf55e38164b240605d0d5f79e7d21a93bd496bb52e9"
+                "sha256:006b28ddd7e55039edf104a1b088ea8f765cb35ed63349857a836bbf2a9c2f84",
+                "sha256:2030638371338662bf1f653e104275504fc0566627e108651c6e5ad8475a5891"
             ],
-            "version": "==0.11.1"
+            "version": "==0.13.0"
         },
         "chardet": {
             "hashes": [
@@ -81,10 +81,12 @@
         },
         "configparser": {
             "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+                "sha256:5bd5fa2a491dc3cfe920a3f2a107510d65eceae10e9c6e547b90261a4710df32",
+                "sha256:c114ff90ee2e762db972fa205f02491b1f5cf3ff950decd8542c62970c9bedac",
+                "sha256:df28e045fbff307a28795b18df6ac8662be3219435560ddb068c283afab1ea7a"
             ],
             "markers": "python_version == '2.7'",
-            "version": "==3.5.0"
+            "version": "==3.7.1"
         },
         "docutils": {
             "hashes": [
@@ -333,16 +335,16 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:e03f19f64d81d0a3099518ca26b04550026f131eced2e76ced7b85c6b8d32128"
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
             ],
-            "version": "==1.11.0"
+            "version": "==1.11.1"
         },
         "yamllint": {
             "hashes": [
-                "sha256:425287ae21320e876d6515cb2ccc0363ae7c6e17a711ef520cf4f579fdb7dfa5",
-                "sha256:9d4ec0da83ce33799e0f87f2882aab8d3ce790d30fe147438c5083c7a26e4044"
+                "sha256:23041a54139691ee0a25622dfcbe529a1d44b4d0d7a5f42097864ac7fb66645f",
+                "sha256:c0a9b641c9f843901fc9261ed71b36f3968c9b04f4c26581cc836d0cabb62a75"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         }
     },
     "develop": {}


### PR DESCRIPTION
bump dependencies, notably:
- boto3
- botocore
- cfn-lint
- yamllint

## Ready State
**Ready**

## Synopsis
ran `pipenv update`.  cfn-lint specifically has been making rapid progress, and its worth staying on top of those changes.
