### PR TITLE
OPS-11530 Update ef_instanceinit.py to skip user group errors

### DIFF
--- a/efopen/ef_instanceinit.py
+++ b/efopen/ef_instanceinit.py
@@ -67,11 +67,27 @@ def critical(message):
   sys.exit(1)
 
 
-def merge_files(service):
+def get_user_group(dest):
+  """
+  Given a dictionary object representing the dest JSON in the late bind config's parameter file, return two
+  values, the user and group
+  Args:
+      dest: dict object from the late bind config's parameters file e.g. dest["user_group"] = "Bob:devops"
+
+  Returns:
+      user: user that the late bind config belongs to
+      group: group that the late bind config belongs to
+
+  """
+  return dest["user_group"].split(":")
+
+
+def merge_files(service, skip_on_user_group_error=False):
   """
   Given a prefix, find all templates below; merge with parameters; write to "dest"
   Args:
-    service: "<service>" or "all"
+    service: "<service>", "all", or "ssh"
+    skip_on_user_group_error: True or False
 
   For S3, full path becomes:
     s3://ellation-cx-global-configs/<service>/templates/<filename>
@@ -102,6 +118,21 @@ def merge_files(service):
         )
         continue
 
+    # If 'dest' for the current object contains a user_group that hasn't been created in the environment yet and the
+    # flag is set to True to skip, log the error and move onto the next config file without blowing up.
+    if skip_on_user_group_error:
+      user, group = get_user_group(dest)
+      try:
+        getpwnam(user).pw_uid
+      except KeyError:
+        log_info("File specifies user {} that doesn't exist in environment. Skipping config file.".format(user))
+        continue
+      try:
+        getgrnam(group).gr_gid
+      except KeyError:
+        log_info("File specifies group {} that doesn't exist in environment. Skipping config file.".format(group))
+        continue
+
     # Process the template_body - apply context + parameters
     log_info("Resolving template")
     resolver.load(config_reader.template, config_reader.parameters)
@@ -127,7 +158,7 @@ def merge_files(service):
       outfile.close()
       log_info("chmod file to: " + dest["file_perm"])
       chmod(dest["path"], int(dest["file_perm"], 8))
-      user, group = dest["user_group"].split(":")
+      user, group = get_user_group(dest)
       uid = getpwnam(user).pw_uid
       gid = getgrnam(group).gr_gid
       log_info("chown last directory in path to: " + dest["user_group"])
@@ -175,6 +206,7 @@ def main():
   log_info("platform: {} service: {}".format(WHERE, service))
 
   merge_files("all")
+  merge_files("ssh", True)
   merge_files(service)
 
   log_info("exit: success")

--- a/efopen/ef_instanceinit.py
+++ b/efopen/ef_instanceinit.py
@@ -206,7 +206,7 @@ def main():
   log_info("platform: {} service: {}".format(WHERE, service))
 
   merge_files("all")
-  merge_files("ssh", True)
+  merge_files("ssh", skip_on_user_group_error=True)
   merge_files(service)
 
   log_info("exit: success")


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Update ef_instanceinit.py to skip user group errors

[OPS-11530](https://ellation.atlassian.net/browse/OPS-11530)

## Testing
Local testing in a very ghetto way, the key thing I wanted to make sure is that it wouldn't explode if the ssh folder in the s3 prod configs bucket didn't exist yet, specifically ssh. It still runs fine so far so it should be safe to merge this tool in first and then perform the ellation_formation change later.