### PR TITLE
Replace the string diff implementation with a native python lib, instead of a subprocess call out to a maybe-missing shell command.

### DIFF
--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -55,11 +55,7 @@ def diff_string_templates(string_a, string_b):
     s1 = string_a.strip().splitlines()
     s2 = string_b.strip().splitlines()
     diffs = unified_diff(s2, s1, fromfile='deployed', tofile='local', lineterm='')
-    diff = '\n'.join(diffs)
-    if diff:
-        return diff
-    else:
-        return ""
+    return '\n'.join(diffs)
 
 
 def render_local_template(service_name, environment, repo_root, template_file):

--- a/efopen/ef_cf_diff.py
+++ b/efopen/ef_cf_diff.py
@@ -49,8 +49,8 @@ service_registry = None
 
 def diff_string_templates(string_a, string_b):
     """
-    Determine the diff of two strings.  Return True if the strings are identical
-    and the diff output string if they are not.
+    Determine the diff of two strings.  Return an empty string if the strings
+    are identical, and the diff output string if they are not.
     """
     s1 = string_a.strip().splitlines()
     s2 = string_b.strip().splitlines()
@@ -59,7 +59,7 @@ def diff_string_templates(string_a, string_b):
     if diff:
         return diff
     else:
-        return True
+        return ""
 
 
 def render_local_template(service_name, environment, repo_root, template_file):
@@ -116,7 +116,7 @@ def diff_sevice_by_text(service_name, service, environment, cf_client, repo_root
         return
 
     ret = diff_string_templates(local_template, current_template)
-    if ret is True:
+    if not ret:
         logger.info('Deployed service `%s` in environment `%s` matches '
                     'the local template.', service_name, environment)
     else:


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Per after-merge review on https://github.com/crunchyroll/ef-open/pull/108#discussion_r253470548
Avoid the subprocess call out to `diff` in favor of a native python lib.

It's worth noting that the python diff lib has a slightly crappier diff algorithm than unix `diff`.  It'd be great if python's difflib had an option for a patience diff algorithm or something similar, but it looks pretty basic.

But this will work alright for our purposes.