### PR TITLE
DA-283 Rollback to specific version

### DIFF
--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -594,15 +594,14 @@ def cmd_rollback(context):
   Args:
     context: a populated EFVersionContext object
   """
-  if isinstance(context.rollback, bool):
-    version = get_latest_stable_version(context)
-  else:
-    version = get_version_by_value(context, context.rollback)
-
-  context.value = version.value
-  context.commit_hash = version.commit_hash
-  context.build_number = version.build_number
-  context.location = version.location
+  last_stable = get_versions(context, return_stable=True)
+  if len(last_stable) != 1:
+    fail("Didn't find a version marked stable for key: {} in env/service: {}/{}".format(
+         context.key, context.env, context.service_name))
+  context.value = last_stable[0].value
+  context.commit_hash = last_stable[0].commit_hash
+  context.build_number = last_stable[0].build_number
+  context.location = last_stable[0].location
   context.stable = True
   cmd_set(context)
 

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -329,7 +329,8 @@ def handle_args_and_set_context(args):
     fail("Error in --limit. Valid range: 1..1000")
   context._limit = parsed_args["limit"]
   context._location = parsed_args["location"]
-  context._rollback = parsed_args["rollback"] or parsed_args["rollback_to"]
+  context._rollback = parsed_args["rollback"]
+  context._rollback_to = parsed_args["rollback_to"]
   context._service_name = parsed_args["service_name"]
   context._show = parsed_args["show"]
   context._stable = parsed_args["stable"]
@@ -762,6 +763,8 @@ def main():
     cmd_history(context)
   elif context.rollback:
     cmd_rollback(context)
+  elif context.rollback_to:
+    cmd_rollback_to(context)
   elif context.show:
     cmd_show(context)
   elif context.value:

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -570,19 +570,20 @@ def get_latest_stable_version(context):
     return last_stable[0]
 
 
-def get_version_by_ami(context):
+def get_version_by_value(context, value):
   """
   Get the latest version that matches the provided ami-id
   Args:
-    context: a populated EFVersionContext object with rollback as string
+    context: a populated EFVersionContext object
+    value: the value of the version to look for
   """
   versions = get_versions(context)
   for version in versions:
-    if version.value == context.rollback:
+    if version.value == value:
       return version
-  fail("Didn't find a version matching ami-id for: "
+  fail("Didn't find a matching version for: "
        "{}:{} in env/service: {}/{}".format(
-          context.key, context.rollback,
+          context.key, value,
           context.env, context.service_name))
 
 
@@ -596,7 +597,7 @@ def cmd_rollback(context):
   if isinstance(context.rollback, bool):
     version = get_latest_stable_version(context)
   else:
-    version = get_version_by_ami(context)
+    version = get_version_by_value(context, context.rollback)
 
   context.value = version.value
   context.commit_hash = version.commit_hash

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -562,20 +562,6 @@ def cmd_history(context):
     print(json.dumps(versions, cls=VersionEncoder))
 
 
-def get_latest_stable_version(context):
-    """
-    Get the latest stable version from the version registry
-    Args:
-      context: a populated EFVersionContext object
-    """
-    last_stable = get_versions(context, return_stable=True)
-    if len(last_stable) != 1:
-      fail("Didn't find a version marked stable for key: "
-           "{} in env/service: {}/{}".format(
-              context.key, context.env, context.service_name))
-    return last_stable[0]
-
-
 def get_version_by_value(context, value):
   """
   Get the latest version that matches the provided ami-id

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -561,10 +561,17 @@ def cmd_rollback(context):
   Args:
     context: a populated EFVersionContext object
   """
-  last_stable = get_versions(context, return_stable=True)
-  if len(last_stable) != 1:
-    fail("Didn't find a version marked stable for key: {} in env/service: {}/{}".format(
-         context.key, context.env, context.service_name))
+  if isinstance(context.rollback, bool):
+    last_stable = get_versions(context, return_stable=True)
+    if len(last_stable) != 1:
+      fail("Didn't find a version marked stable for key: "
+        "{} in env/service: {}/{}".format(
+            context.key, context.env, context.service_name))
+  else:
+    versions = get_versions(context)
+    for version in versions:
+      if version.value == context.rollback:
+        last_stable = [version]
   context.value = last_stable[0].value
   context.commit_hash = last_stable[0].commit_hash
   context.build_number = last_stable[0].build_number

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -276,6 +276,8 @@ def handle_args_and_set_context(args):
   group.add_argument("--set", help="set current version of <key> to <value> for <service_name>")
   group.add_argument("--rollback", help="set current version to most recent 'stable' version in history",
                      action="store_true")
+  group.add_argument("--rollback-to", help="rollback current version to <ami-id> in history",
+                     action="store", metavar='<ami-id>')
   group.add_argument("--history", help="Show version history for env/service/key", choices=['json', 'text'])
   group.add_argument("--show", help="Show keys and values. '*' allowed for <key> and <env>",
                      action="store_true", default=False)
@@ -322,7 +324,7 @@ def handle_args_and_set_context(args):
     fail("Error in --limit. Valid range: 1..1000")
   context._limit = parsed_args["limit"]
   context._location = parsed_args["location"]
-  context._rollback = parsed_args["rollback"]
+  context._rollback = parsed_args["rollback"] or parsed_args["rollback_to"]
   context._service_name = parsed_args["service_name"]
   context._show = parsed_args["show"]
   context._stable = parsed_args["stable"]

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -571,7 +571,15 @@ def cmd_rollback(context):
     versions = get_versions(context)
     for version in versions:
       if version.value == context.rollback:
+        # hacky way to change less code
         last_stable = [version]
+        break
+    else:
+      fail("Didn't find a version matching ami-id for: "
+        "{}:{} in env/service: {}/{}".format(
+            context.key, context.rollback,
+            context.env, context.service_name))
+
   context.value = last_stable[0].value
   context.commit_hash = last_stable[0].commit_hash
   context.build_number = last_stable[0].build_number

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -56,6 +56,7 @@ class EFVersionContext(EFContext):
     self._limit = None
     self._noprecheck = None
     self._rollback = None
+    self._rollback_to = ""
     self._service_name = None # Cheating - we don't care about the full service record so don't use context.service
     self._show = None
     self._stable = None
@@ -130,6 +131,10 @@ class EFVersionContext(EFContext):
   @property
   def rollback(self):
     return self._rollback
+
+  @property
+  def rollback_to(self):
+    return self._rollback_to
 
   @property
   def service_name(self):
@@ -602,6 +607,22 @@ def cmd_rollback(context):
   context.commit_hash = last_stable[0].commit_hash
   context.build_number = last_stable[0].build_number
   context.location = last_stable[0].location
+  context.stable = True
+  cmd_set(context)
+
+
+def cmd_rollback_to(context):
+  """
+  Roll back by finding a specific version in the history of the service and
+  putting it as the new current version.
+  Args:
+    context: a populated EFVersionContext object
+  """
+  version = get_version_by_value(context, context.rollback_to)
+  context.value = version.value
+  context.commit_hash = version.commit_hash
+  context.build_number = version.build_number
+  context.location = version.location
   context.stable = True
   cmd_set(context)
 

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -565,8 +565,8 @@ def cmd_rollback(context):
     last_stable = get_versions(context, return_stable=True)
     if len(last_stable) != 1:
       fail("Didn't find a version marked stable for key: "
-        "{} in env/service: {}/{}".format(
-            context.key, context.env, context.service_name))
+           "{} in env/service: {}/{}".format(
+             context.key, context.env, context.service_name))
   else:
     versions = get_versions(context)
     for version in versions:
@@ -576,9 +576,9 @@ def cmd_rollback(context):
         break
     else:
       fail("Didn't find a version matching ami-id for: "
-        "{}:{} in env/service: {}/{}".format(
-            context.key, context.rollback,
-            context.env, context.service_name))
+           "{}:{} in env/service: {}/{}".format(
+             context.key, context.rollback,
+             context.env, context.service_name))
 
   context.value = last_stable[0].value
   context.commit_hash = last_stable[0].commit_hash

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -134,7 +134,7 @@ class TestEFVersion(unittest.TestCase):
     """Test parsing args with all valid values for --rollback-to"""
     args = [self.service, self.key, self.env, "--rollback-to", self.value, "--sr", "{}".format(self.service_registry_file)]
     context = ef_version.handle_args_and_set_context(args)
-    self.assertEqual(context.rollback, self.value)
+    self.assertEqual(context.rollback_to, self.value)
     self.assertEqual(context.env, self.env)
     self.assertEqual(context.service_name, self.service_name)
 

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -351,19 +351,19 @@ class TestEFVersionModule(unittest.TestCase):
   @patch('ef_version.cmd_set')
   @patch('ef_version.get_versions')
   def test_cmd_rollback_to_unknown_ami(self, get_versions, cmd_set):
-    '''Test cmd_rollback fails on missing ami_id in history'''
+    '''Test cmd_rollback_to fails on missing ami_id in history'''
     ami_id = "ami-abcdefgh12345678"
     context = Mock(ef_version.EFVersionContext)
     context.env = "alpha0"
     context.key = "ami-id"
     context.limit = 10
     context.service_name = "playheads"
-    context.rollback = ami_id
+    context.rollback_to = ami_id
 
     get_versions.return_value = self.versions
 
     with self.assertRaises(SystemExit) as e:
-      ef_version.cmd_rollback(context)
+      ef_version.cmd_rollback_to(context)
       self.assertIn(ami_id, e.message)
 
     get_versions.assert_called_once_with(context)

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -313,7 +313,7 @@ class TestEFVersionModule(unittest.TestCase):
   @patch('ef_version.cmd_set')
   @patch('ef_version.get_versions')
   def test_cmd_rollback_to_ami(self, get_versions, cmd_set):
-    '''Test cmd_rollback to the latest stable version'''
+    '''Test cmd_rollback to a specific ami version'''
     ami_id = "ami-abcdefgh12345678"
     desired_version = ef_version.Version({
         u'Body': StringIO.StringIO(ami_id),
@@ -332,12 +332,12 @@ class TestEFVersionModule(unittest.TestCase):
     context.key = "ami-id"
     context.limit = 10
     context.service_name = "playheads"
-    context.rollback = ami_id
+    context.rollback_to = ami_id
 
     # inserting at the end so the code doesn't take the first one
     get_versions.return_value = self.versions + [desired_version]
 
-    ef_version.cmd_rollback(context)
+    ef_version.cmd_rollback_to(context)
     self.assertEqual(context.stable, True)
     self.assertEqual(context.value, desired_version.value)
     self.assertEqual(context.build_number, desired_version.build_number)

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -330,3 +330,25 @@ class TestEFVersionModule(unittest.TestCase):
 
     get_versions.assert_called_once_with(context)
     cmd_set.assert_called_once_with(context)
+
+
+  @patch('ef_version.cmd_set')
+  @patch('ef_version.get_versions')
+  def test_cmd_rollback_to_unknown_ami(self, get_versions, cmd_set):
+    '''Test cmd_rollback fails on missing ami_id in history'''
+    ami_id = "ami-abcdefgh12345678"
+    context = Mock(ef_version.EFVersionContext)
+    context.env = "alpha0"
+    context.key = "ami-id"
+    context.limit = 10
+    context.service_name = "playheads"
+    context.rollback = ami_id
+
+    get_versions.return_value = self.versions
+
+    with self.assertRaises(SystemExit) as e:
+      ef_version.cmd_rollback(context)
+      self.assertIn(ami_id, e.message)
+
+    get_versions.assert_called_once_with(context)
+    cmd_set.assert_not_called()

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -122,6 +122,22 @@ class TestEFVersion(unittest.TestCase):
     self.assertEqual(context.service_name, self.service_name)
     self.assertEqual(context.service_registry.filespec, self.service_registry_file)
 
+  def test_args_rollback(self):
+    """Test parsing args with all valid values for --rollback"""
+    args = [self.service, self.key, self.env, "--rollback", "--sr", "{}".format(self.service_registry_file)]
+    context = ef_version.handle_args_and_set_context(args)
+    self.assertEqual(context.rollback, True)
+    self.assertEqual(context.env, self.env)
+    self.assertEqual(context.service_name, self.service_name)
+
+  def test_args_rollback_to(self):
+    """Test parsing args with all valid values for --rollback-to"""
+    args = [self.service, self.key, self.env, "--rollback-to", self.value, "--sr", "{}".format(self.service_registry_file)]
+    context = ef_version.handle_args_and_set_context(args)
+    self.assertEqual(context.rollback, self.value)
+    self.assertEqual(context.env, self.env)
+    self.assertEqual(context.service_name, self.service_name)
+
   def test_args_set(self):
     """Test parsing args with all valid values for set"""
     args = [self.service, self.key, self.env, "--set", self.value, "--location", self.location, "--build",

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import datetime
 import os
 import unittest
+import StringIO
 
 from mock import Mock, patch
 
@@ -200,3 +202,94 @@ class TestEFVersion(unittest.TestCase):
     response = {"Error": {"Code": "NoSuchKey"}}
     mock_version_object.side_effect = ClientError(response, "Get Object")
     self.assertTrue(ef_version.precheck_dist_hash(self))
+
+class TestEFVersionModule(unittest.TestCase):
+
+  def setUp(self):
+    self.versions = map(
+        ef_version.Version, [
+            {
+                u'Body': StringIO.StringIO("ami-0f85b8e7ca0788951"),
+                u'LastModified': datetime.datetime(2019, 2, 4, 5, 44, 26),
+                u'VersionId': 'CZmfHynYjwlH92LlOa1Oc7EurAfT_ZaM',
+                u'Metadata': {
+                    'ef-buildnumber': '258',
+                    'ef-commithash': '338432d7e23e93dcf957e62598800468a17ff6d1',
+                    'ef-location': '',
+                    'ef-modifiedby': 'arn:aws:iam::097710525421:user/ci',
+                    'ef-version-status': 'stable'}},
+            {
+                u'Body': StringIO.StringIO("ami-0f85b8e7ca0788951"),
+                u'LastModified': datetime.datetime(2019, 2, 4, 5, 35, 6),
+                u'VersionId': '2WndwRGdS.nolumBcURZFZsMLhSKvfYi',
+                u'Metadata': {
+                    'ef-buildnumber': '258',
+                    'ef-commithash': '338432d7e23e93dcf957e62598800468a17ff6d1',
+                    'ef-location': '',
+                    'ef-modifiedby': 'arn:aws:iam::097710525421:user/ci',
+                    'ef-version-status': 'undefined'}},
+            {
+                u'Body': StringIO.StringIO("ami-07106419da94f1568"),
+                u'LastModified': datetime.datetime(2019, 2, 1, 6, 4, 53),
+                u'VersionId': 'bYdch7nPOWINnzdYPm8lZ9_r_9LTgyFt',
+                u'Metadata': {
+                    'ef-buildnumber': '257',
+                    'ef-commithash': '338432d7e23e93dcf957e62598800468a17ff6d1',
+                    'ef-location': '',
+                    'ef-modifiedby': 'arn:aws:iam::097710525421:user/ci',
+                    'ef-version-status': 'stable'}},
+            {
+                u'Body': StringIO.StringIO("ami-07106419da94f1568"),
+                u'LastModified': datetime.datetime(2019, 2, 1, 5, 54, 37),
+                u'VersionId': 'zgT2aQliuYKqBqbFNme3dl3l_sAzTni8',
+                u'Metadata': {
+                    'ef-buildnumber': '257',
+                    'ef-commithash': '338432d7e23e93dcf957e62598800468a17ff6d1',
+                    'ef-location': '',
+                    'ef-modifiedby': 'arn:aws:iam::097710525421:user/ci',
+                    'ef-version-status': 'undefined'}},
+            {
+                u'Body': StringIO.StringIO("ami-053bd53d8210575aa"),
+                u'LastModified': datetime.datetime(2019, 1, 31, 5, 44, 16),
+                u'VersionId': '1ao3Qo4.jj_CZbidXp9oaP4yOpmpq_Se',
+                u'Metadata': {
+                    'ef-buildnumber': '256',
+                    'ef-commithash': '338432d7e23e93dcf957e62598800468a17ff6d1',
+                    'ef-location': '',
+                    'ef-modifiedby': 'arn:aws:iam::097710525421:user/ci',
+                    'ef-version-status': 'stable'}},
+            {
+                u'Body': StringIO.StringIO("ami-053bd53d8210575aa"),
+                u'LastModified': datetime.datetime(2019, 1, 31, 5, 33, 24),
+                u'VersionId': 'b0tRbmuz7HsSMzrPaDxwUORqdQMisi9h',
+                u'Metadata': {
+                    'ef-buildnumber': '256',
+                    'ef-commithash': '338432d7e23e93dcf957e62598800468a17ff6d1',
+                    'ef-location': '',
+                    'ef-modifiedby': 'arn:aws:iam::097710525421:user/ci',
+                    'ef-version-status': 'undefined'}},
+        ])
+
+  @patch('ef_version.cmd_set')
+  @patch('ef_version.get_versions')
+  def test_cmd_rollback_latest_stable(self, get_versions, cmd_set):
+    '''Test cmd_rollback to the latest stable version'''
+    context = Mock(ef_version.EFVersionContext)
+    context.env = "alpha0"
+    context.key = "ami-id"
+    context.limit = 10
+    context.service_name = "playheads"
+    context.rollback = True
+
+    latest_stable = self.versions[0]
+    get_versions.return_value = [latest_stable]
+
+    ef_version.cmd_rollback(context)
+    self.assertEqual(context.stable, True)
+    self.assertEqual(context.value, latest_stable.value)
+    self.assertEqual(context.build_number, latest_stable.build_number)
+    self.assertEqual(context.commit_hash, latest_stable.commit_hash)
+    self.assertEqual(context.location, latest_stable.location)
+
+    get_versions.assert_called_once_with(context, return_stable=True)
+    cmd_set.assert_called_once_with(context)


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Often times it is required to rollback a service to a specific AMI, like a few versions back of some services. 
This PR adds a `--rollback-to` option to `ef-version` to enable re-setting the current version to a version in the history of the service.
[DA-283](https://ellation.atlassian.net/browse/DA-283)
## Changelog
- add a `--rollback-to` flag
- add rollback to an AMI functionality to cmd_rollback
- test cover cmd_rollback
## Testing
1. Run the unit-tests
For a real-life test, run
```
ef-version --history text playheads ami-id alpha0
```
pick a previous version and use the current code-base to run
```
ef_version playheads ami-id alpha0 --rollback-to <ami-version> --devel --commit
```