### PR TITLE
Make json linting be non-strict to allow for control characters.

### DIFF
--- a/efopen/ef_resolve_config.py
+++ b/efopen/ef_resolve_config.py
@@ -138,7 +138,7 @@ def merge_files(context):
   if context.lint:
     if context.template_path.endswith(".json"):
       try:
-        json.loads(rendered_body)
+        json.loads(rendered_body, strict=False)
         print("JSON passed linting process.")
       except ValueError as e:
         fail("JSON failed linting process.", e)


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
The json linter chokes on escape characters in strings. This will let them through.
This blocks the ticket below.
[ESS-1598](https://ellation.atlassian.net/browse/ESS-1598)
## Changelog

## Dependencies
## Linked PRs
## Testing
###### [Markdown support](https://guides.github.com/features/mastering-markdown/)
