### PR TITLE
Add a safe default max batch size

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -172,6 +172,9 @@ def enable_stack_termination_protection(clients, stack_name):
 
 def calculate_max_batch_size(asg_client, service, percent):
   autoscaling_group_properties = get_autoscaling_group_properties(asg_client, service.split("-")[0], "-".join(service.split("-")[1:]))
+  if not autoscaling_group_properties:
+      # safe default
+      return 1
   current_desired = autoscaling_group_properties[0]["DesiredCapacity"]
   new_batch_size = int(math.ceil(current_desired * (percent * 0.01)))
   return new_batch_size


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
If we use the percent flag when we deploy services that are not in prod, it is possible not to get an actual result. Setting 1 as the max batch size is a safe default as it will allow the service to continue updating even if there was some mistake.
## Changelog
- add safe default for max_batch_size
