### PR TITLE
add aws_lambda to dish-hash ef-version key

### DIFF
--- a/efopen/ef_config.py
+++ b/efopen/ef_config.py
@@ -103,7 +103,7 @@ class EFConfig(object):
       },
       "config": {},
       "dist-hash": {
-          "allowed_types": ["dist_static"]
+          "allowed_types": ["dist_static", "aws_lambda"]
       }
   }
   # Some envs' version entries can be set via these special values, meaning 'use the value found there'


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
Allow the use of the dist-hash key in ef-version for lambdas. We have been discussing using this to version and distribute lambda's to different environments.
## Changelog
- add "aws_lambda" object type to dist-hash array. 
