### PR TITLE
Add mechanism for linking roles to "Customer Managed" policies (as opposed to just AWS Managed policies)

### DIFF
--- a/tests/test_data/test_service_registry_1.json
+++ b/tests/test_data/test_service_registry_1.json
@@ -7,6 +7,7 @@
       "team_email": "email@example.com",
       "environments": ["global.ellationeng"],
       "aws_managed_policies": ["AwsManagedPolicy"],
+      "customer_managed_policies": ["CustomerManagedPolicy"],
       "policies": ["policy_1", "policy_2"],
       "assume_role_policy": "assume_role_policy"
     },

--- a/tests/unit_tests/test_ef_generate.py
+++ b/tests/unit_tests/test_ef_generate.py
@@ -56,7 +56,7 @@ class TestEFGenerate(unittest.TestCase):
     Check that when an existing key is not found that the create key/alias methods are called with the correct
     parameters.
     """
-    ef_generate.conditionally_attach_managed_policies(self.role_name,
+    ef_generate.conditionally_attach_aws_managed_policies(self.role_name,
                                                       self.service_registry['fixtures']['test-role'])
 
     self.mock_iam.attach_role_policy.assert_called_with(
@@ -64,12 +64,27 @@ class TestEFGenerate(unittest.TestCase):
       PolicyArn='arn:aws:iam::aws:policy/{}'.format(self.service_registry['fixtures']['test-role']['aws_managed_policies'][0])
     )
 
+  def test_attach_customer_managed_policies(self):
+    """
+    Check that when an existing key is not found that the create key/alias methods are called with the correct
+    parameters.
+    """
+    ef_generate.conditionally_attach_customer_managed_policies(self.role_name,
+                                                      self.service_registry['fixtures']['test-role'])
+
+    self.mock_iam.attach_role_policy.assert_called_with(
+      RoleName=self.role_name,
+      PolicyArn='arn:aws:iam::{}:policy/{}'.format(
+        ef_generate.CONTEXT.account_id,
+        self.service_registry['fixtures']['test-role']['customer_managed_policies'][0])
+    )
+
   def test_not_service_type_for_managed_policy(self):
     """
     Validates that a managed policy is not attached for unsupported service types
     """
     self.service_type = {"type": "invalid_service"}
-    ef_generate.conditionally_attach_managed_policies(self.role_name, self.service_type)
+    ef_generate.conditionally_attach_aws_managed_policies(self.role_name, self.service_type)
 
     self.mock_iam.attach_role_policy.assert_not_called()
 
@@ -77,7 +92,7 @@ class TestEFGenerate(unittest.TestCase):
     """
     Validates that a managed policy is not attached services without the 'aws_managed_policies' key
     """
-    ef_generate.conditionally_attach_managed_policies(self.role_name,
+    ef_generate.conditionally_attach_aws_managed_policies(self.role_name,
                                                       self.service_registry['fixtures']['test-role-2'])
 
     self.mock_iam.attach_role_policy.assert_not_called()


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Note that it only throws a warning if the managed policy doesn't exist, instead of a halting error.  This is to avoid the "can't deploy because the policy doesn't exist yet" scenario.