### PR TITLE
Add the long description type to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
     author='Ellation, Inc.',
     author_email='ops@ellation.com',
     description='CloudFormation Tools by Ellation',
-    long_description=readme()
+    long_description=readme(),
+    long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
to address a failure to publish bug

Turns out, they changed stuff in pypi's codebase:
https://github.com/pypa/warehouse/pull/5835
https://github.com/pypa/warehouse/issues/5890

## Ready State
**Ready**

## Synopsis
ef-open has been failing builds on the publish step for a while now, and no one noticed.
https://jenkins-build.ellationeng.cx-mgmt.com/job/ef-open/228/console

Turns out pypi tightened its validation around readme files, of all things.