### PR TITLE
Remove additional prints in ef-version

### DIFF
--- a/efopen/ef_site_config.py
+++ b/efopen/ef_site_config.py
@@ -42,9 +42,7 @@ class EFSiteConfig(object):
       try:
         return self.load_from_ssm()
       except ClientError as e:
-        print("Could not load parameter {} from SSM@{}".format(self.ssm_parameter_name, self.ssm_region))
-        print(e.message)
-        print("falling back to local file")
+        pass
     return self.load_from_local_file()
 
   def load_from_ssm(self):


### PR DESCRIPTION
## Ready State

**Ready**
## Synopsis
On a EC2 machine ef-version outputs and error message when not able to read from ssm. This interferes with our pipeline reading the versions. This is a hotfix, an actual fix for proper error handling and logging will be coming soon.
[OPS-12902](https://ellation.atlassian.net/browse/OPS-12902)
## Changelog
- remove error output when SSM read fails
