### PR TITLE
Allow `*` symbol in ef-open lookup

### DIFF
--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -30,7 +30,7 @@ from ef_version_resolver import EFVersionResolver
 
 # CONSTANTS
 # pattern to find resolvable symbols - finds innermost nestings
-SYMBOL_PATTERN = r'{{([0-9A-Za-z/_,.:\-\+=]+?)}}'
+SYMBOL_PATTERN = r'{{([0-9A-Za-z/_,.:\-\+=\*]+?)}}'
 # inverse of SYMBOL_PATTERN, and disallows ':' and ',' from param keys; this is checked in load()
 ILLEGAL_PARAMETER_CHARS = r'[^(0-9A-Za-z/_.\-)]'
 


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Allow `*` symbol in ef-open lookup. Example lookup that needs to be resolved: 
```
"{{aws:acm:certificate-arn,us-east-1/*.example.com,NONE}}",
```

## Changelog
  * Allow `*` symbol in ef-open lookup

## Testing
```
Jerrys-Mac-mini:ef-open jwong$ pytest tests/unit_tests/test_ef_template_resolver.py --cov ef_utils -v --cov-report term-missing --disable-pytest-warnings
====================================================== test session starts =======================================================
platform darwin -- Python 2.7.15, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.6.0
collected 11 items

tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_context_vars_protected PASSED                  [  9%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_embedded_symbols PASSED                        [ 18%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_fully_qualified_env PASSED                     [ 27%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_hierarchical_overlays PASSED                   [ 36%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_load_json_file PASSED                          [ 45%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_load_yaml_file PASSED                          [ 54%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string PASSED                 [ 63%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string_from_list PASSED       [ 72%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string_from_string PASSED     [ 81%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_resolution PASSED                              [ 90%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_unresolved_symbols PASSED                      [100%]

---------- coverage: platform darwin, python 2.7.15-final-0 ----------
Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
efopen/ef_utils.py     148     98    34%   49-52, 67-69, 81-84, 99-100, 107, 117, 124-128, 135-139, 154-180, 203-216, 229-241, 253-259, 275-291, 300-315


=================================================== 11 passed in 5.36 seconds ====================================================
Jerrys-Mac-mini:ef-open jwong$
```