### PR TITLE
Fix lookup to also work on mgmt.<account_alias>

### DIFF
--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -390,9 +390,9 @@ class EFTemplateResolver(object):
       result = self.parameters["default"][symbol]
     if self.resolved["ENV_SHORT"] in self.parameters and symbol in self.parameters[self.resolved["ENV_SHORT"]]:
       result = self.parameters[self.resolved["ENV_SHORT"]][symbol]
-    # This lookup is redundant when env_short == env, but it's also cheap
-    if self.resolved["ENV"] in self.parameters and symbol in self.parameters[self.resolved["ENV"]]:
-      result = self.parameters[self.resolved["ENV"]][symbol]
+    # This lookup is redundant when env_short == env_full, but it's also cheap. Also handles the case for mgmt.<account_alias>
+    if self.resolved["ENV_FULL"] in self.parameters and symbol in self.parameters[self.resolved["ENV_FULL"]]:
+      result = self.parameters[self.resolved["ENV_FULL"]][symbol]
     return result
 
   def render(self):


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Fix lookup to also work on mgmt.<account_alias>

## Changelog
  * Fix lookup to also work on mgmt.<account_alias>

## Testing
```
Jerrys-Mac-mini:ef-open jwong$ pytest tests/unit_tests/test_ef_template_resolver.py --cov ef_utils -v --cov-report term-missing --disable-pytest-warnings
====================================================== test session starts =======================================================
platform darwin -- Python 2.7.15, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.6.0
collected 11 items

tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_context_vars_protected PASSED                  [  9%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_embedded_symbols PASSED                        [ 18%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_fully_qualified_env PASSED                     [ 27%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_hierarchical_overlays PASSED                   [ 36%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_load_json_file PASSED                          [ 45%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_load_yaml_file PASSED                          [ 54%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string PASSED                 [ 63%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string_from_list PASSED       [ 72%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string_from_string PASSED     [ 81%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_resolution PASSED                              [ 90%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_unresolved_symbols PASSED                      [100%]

---------- coverage: platform darwin, python 2.7.15-final-0 ----------
Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
efopen/ef_utils.py     148     98    34%   49-52, 67-69, 81-84, 99-100, 107, 117, 124-128, 135-139, 154-180, 203-216, 229-241, 253-259, 275-291, 300-315


=================================================== 11 passed in 2.32 seconds ====================================================
Jerrys-Mac-mini:ef-open jwong$ pytest tests/unit_tests/ --cov ef_utils -v --cov-report term-missing --disable-pytest-warnings
====================================================== test session starts =======================================================
platform darwin -- Python 2.7.15, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.6.0
collected 206 items

tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn PASSED                               [  0%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_bad_input PASSED                     [  0%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_multiple_matching_certificates PASSED [  1%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_no_match PASSED                      [  1%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_old_matching_certificate_has_no_issued_date PASSED [  2%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_acm_certificate_arn_target_certificate_has_no_issued_date PASSED [  2%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name PASSED                            [  3%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name_is_truncated PASSED               [  3%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_domain_name_no_match PASSED                   [  4%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id PASSED [  4%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id_is_truncated PASSED [  5%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_canonical_user_id_no_match PASSED [  5%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id PASSED          [  6%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id_is_truncated PASSED [  6%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cloudfront_origin_access_identity_oai_id_no_match PASSED [  7%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_identity_identity_pool_arn PASSED                [  7%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_identity_identity_pool_arn_no_match PASSED       [  8%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_identity_identity_pool_id PASSED                 [  8%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_identity_identity_pool_id_no_match PASSED        [  9%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_idp_user_pool_arn PASSED                         [  9%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_idp_user_pool_arn_no_match PASSED                [ 10%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_idp_user_pool_id PASSED                          [ 10%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_cognito_idp_user_pool_id_no_match PASSED                 [ 11%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_id PASSED                        [ 11%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_id_bad_input PASSED              [ 12%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_ipaddress PASSED                 [ 12%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_elasticip_elasticip_ipaddress_bad_input PASSED       [ 13%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_eni_eni_id PASSED                                    [ 13%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_eni_eni_id_no_match PASSED                           [ 14%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_network_network_acl_id PASSED                        [ 14%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_network_network_acl_id_no_match PASSED               [ 15%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_route_table_main_route_table_id PASSED               [ 15%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_route_table_main_route_table_id_no_single_match PASSED [ 16%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_security_group_security_group_id PASSED              [ 16%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_security_group_security_group_id_no_match PASSED     [ 16%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_cidr PASSED                            [ 17%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_cidr_no_match PASSED                   [ 17%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_id PASSED                              [ 18%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_subnet_subnet_id_no_match PASSED                     [ 18%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones PASSED                         [ 19%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones_no_match PASSED                [ 19%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_availabilityzones_no_vpc_id PASSED               [ 20%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_cidrblock PASSED                                 [ 20%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_cidrblock_no_match PASSED                        [ 21%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_subnets PASSED                                   [ 21%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_subnets_no_match PASSED                          [ 22%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_vpc_id PASSED                                    [ 22%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_ec2_vpc_vpc_id_none PASSED                               [ 23%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_elbv2_load_balancer_arn_suffix PASSED                    [ 23%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_elbv2_load_balancer_dns_name PASSED                      [ 24%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_elbv2_load_balancer_hosted_zone PASSED                   [ 24%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_elbv2_load_balancer_no_such_elb PASSED                   [ 25%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_elbv2_target_group_arn_suffix PASSED                     [ 25%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_kms_key_arn PASSED                                       [ 26%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_kms_key_arn_key_does_not_exist PASSED                    [ 26%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_lookup_invalid_input PASSED                              [ 27%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id PASSED                    [ 27%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_is_truncated PASSED       [ 28%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_malformed_domain_name PASSED [ 28%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_private_hosted_zone_id_no_match PASSED           [ 29%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id PASSED                     [ 29%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_is_truncated PASSED        [ 30%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_malformed_domain_name PASSED [ 30%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_route53_public_hosted_zone_id_no_match PASSED            [ 31%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id PASSED                                       [ 31%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id_more_rules_than_limit PASSED                 [ 32%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_rule_id_no_match PASSED                              [ 32%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id PASSED                                    [ 33%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id_more_web_acls_than_limit PASSED           [ 33%]
tests/unit_tests/test_ef_aws_resolver.py::TestEFAwsResolver::test_waf_web_acl_id_no_match PASSED                           [ 33%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_env_valid PASSED                                             [ 34%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_env_valid_invalid_envs PASSED                                [ 34%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_get_account_alias PASSED                                     [ 35%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_get_account_alias_invalid_env PASSED                         [ 35%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_get_env_short PASSED                                         [ 36%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_get_env_short_invalid_envs PASSED                            [ 36%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_get_template_parameters_file PASSED                          [ 37%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_get_template_parameters_s3 PASSED                            [ 37%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_global_env_valid PASSED                                      [ 38%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_global_env_valid_non_scoped_envs PASSED                      [ 38%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_pull_repo_https_credentials PASSED                           [ 39%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_pull_repo_incorrect_branch PASSED                            [ 39%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_pull_repo_incorrect_repo PASSED                              [ 40%]
tests/unit_tests/test_ef_conf_utils.py::TestEFConfUtils::test_pull_repo_ssh_credentials PASSED                             [ 40%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_account_alias_list_missing_group PASSED                             [ 41%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_account_alias_list_type_set PASSED                                  [ 41%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_account_alias_list_values PASSED                                    [ 42%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_account_map PASSED                                              [ 42%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_account_map_missing_env PASSED                                  [ 43%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_list_includes_ephemeral PASSED                                  [ 43%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_list_includes_global PASSED                                     [ 44%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_list_includes_mgmt PASSED                                       [ 44%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_list_includes_no_ephemeral PASSED                               [ 45%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_env_list_includes_non_ephemeral PASSED                              [ 45%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_service_groups PASSED                                               [ 46%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_service_groups_has_fixtures PASSED                                  [ 46%]
tests/unit_tests/test_ef_config.py::TestEFConfig::test_service_groups_missing_group PASSED                                 [ 47%]
tests/unit_tests/test_ef_config_resolver.py::TestEFConfigResolver::test_account_alias_of_env PASSED                        [ 47%]
tests/unit_tests/test_ef_config_resolver.py::TestEFConfigResolver::test_config_custom_data PASSED                          [ 48%]
tests/unit_tests/test_ef_config_resolver.py::TestEFConfigResolver::test_config_custom_data_missing_lookup PASSED           [ 48%]
tests/unit_tests/test_ef_config_resolver.py::TestEFConfigResolver::test_config_custom_data_no_data PASSED                  [ 49%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_attach_customer_managed_policies PASSED                         [ 49%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_attach_managed_policies PASSED                                  [ 50%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_create_kms_key PASSED                                           [ 50%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_create_kms_key_subservice PASSED                                [ 50%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_create_key_eventual_consistency_failure PASSED              [ 51%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_eventual_consistency_resilience PASSED                      [ 51%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_key_already_exists PASSED                                   [ 52%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_kms_service_type_fixture PASSED                                 [ 52%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_no_aws_managed_policies_key_in_service PASSED                   [ 53%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_not_kms_service_type PASSED                                     [ 53%]
tests/unit_tests/test_ef_generate.py::TestEFGenerate::test_not_service_type_for_managed_policy PASSED                      [ 54%]
tests/unit_tests/test_ef_instanceinit_config_reader.py::TestEFInstanceInitConfigReader::test_config_parameters_from_file PASSED [ 54%]
tests/unit_tests/test_ef_instanceinit_config_reader.py::TestEFInstanceInitConfigReader::test_config_parameters_from_s3 PASSED [ 55%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_decrypt PASSED                                             [ 55%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_invalid_env PASSED                                         [ 56%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_length_too_small PASSED                                    [ 56%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_nonint_length PASSED                                       [ 57%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_plaintext PASSED                                           [ 57%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_secret_file PASSED                                         [ 58%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_without_match PASSED                                       [ 58%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_args_without_secret_file PASSED                                 [ 59%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_generate_secret PASSED                                          [ 59%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_generate_secret_file PASSED                                     [ 60%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main PASSED                                                     [ 60%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_decrypt PASSED                                             [ 61%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_plaintext PASSED                                           [ 61%]
tests/unit_tests/test_ef_password.py::TestEFPassword::test_main_secret_file_parameters PASSED                              [ 62%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_service_group PASSED                                       [ 62%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_service_region PASSED                                      [ 63%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_service_region_override PASSED                             [ 63%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_service_region_override_negative PASSED                    [ 64%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_services PASSED                                            [ 64%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_services_one_group PASSED                                  [ 65%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_sr_loads PASSED                                            [ 65%]
tests/unit_tests/test_ef_service_registry.py::TestEFUtils::test_valid_envs PASSED                                          [ 66%]
tests/unit_tests/test_ef_site_config.py::TestEFSiteConfig::test_load_from_ssm PASSED                                       [ 66%]
tests/unit_tests/test_ef_site_config.py::TestEFSiteConfig::test_site_config_load_from_ssm_on_ec2 PASSED                    [ 66%]
tests/unit_tests/test_ef_site_config.py::TestEFSiteConfig::test_site_config_load_local_on_non_ec2 PASSED                   [ 67%]
tests/unit_tests/test_ef_site_config.py::TestEFSiteConfig::test_site_load_local_file PASSED                                [ 67%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_context_vars_protected PASSED                  [ 68%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_embedded_symbols PASSED                        [ 68%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_fully_qualified_env PASSED                     [ 69%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_hierarchical_overlays PASSED                   [ 69%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_load_json_file PASSED                          [ 70%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_load_yaml_file PASSED                          [ 70%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string PASSED                 [ 71%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string_from_list PASSED       [ 71%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_render_multiline_string_from_string PASSED     [ 72%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_resolution PASSED                              [ 72%]
tests/unit_tests/test_ef_template_resolver.py::TestEFTemplateResolver::test_unresolved_symbols PASSED                      [ 73%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients PASSED                                             [ 73%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_cache_multiple_configs PASSED                      [ 74%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_cache_new_clients PASSED                           [ 74%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_cache_same_client PASSED                           [ 75%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_create_aws_clients_no_profile PASSED                                  [ 75%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_None_message PASSED                                         [ 76%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_empty_string PASSED                                         [ 76%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_message PASSED                                              [ 77%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_fail_with_message_and_exception_data PASSED                           [ 77%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_account_id PASSED                                                 [ 78%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_autoscaling_group_properties_valid_asg_name PASSED                [ 78%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_autoscaling_group_properties_valid_tag_name PASSED                [ 79%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context PASSED                                       [ 79%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_get_instance_aws_context_metadata_exception PASSED                    [ 80%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_env PASSED                                          [ 80%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_env_exception PASSED                                [ 81%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_role PASSED                                         [ 81%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_instance_role_exception PASSED                               [ 82%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_metadata_200_status_code PASSED                              [ 82%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_http_get_metadata_non_200_status_code PASSED                          [ 83%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_ec2 PASSED                                                   [ 83%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_local PASSED                                                 [ 83%]
tests/unit_tests/test_ef_utils.py::TestEFUtils::test_whereami_unknown PASSED                                               [ 84%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_call PASSED                                            [ 84%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_client_error PASSED                              [ 85%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_decrypt_fails_without_b64_secret PASSED                        [ 85%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call PASSED                                            [ 86%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_call_subservice PASSED                                 [ 86%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_fails_client_error PASSED                              [ 87%]
tests/unit_tests/test_ef_utils.py::TestEFUtilsKMS::test_kms_encrypt_returns_b64 PASSED                                     [ 87%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_get PASSED                                                   [ 88%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_get_force_env_full PASSED                                    [ 88%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_get_force_env_full_env_not_account_scoped PASSED             [ 89%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_get_parse_env_full PASSED                                    [ 89%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_history PASSED                                               [ 90%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_invalid_env PASSED                                           [ 90%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_rollback PASSED                                              [ 91%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_rollback_to PASSED                                           [ 91%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_args_set PASSED                                                   [ 92%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_noprecheck PASSED                                                 [ 92%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_precheck PASSED                                                   [ 93%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_precheck_dist_hash PASSED                                         [ 93%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_precheck_dist_hash_s3_404 PASSED                                  [ 94%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_precheck_dist_hash_urllib_error PASSED                            [ 94%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_precheck_dist_hash_version_none PASSED                            [ 95%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_validate_context PASSED                                           [ 95%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_validate_context_invalid_key PASSED                               [ 96%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_validate_context_invalid_service PASSED                           [ 96%]
tests/unit_tests/test_ef_version.py::TestEFVersion::test_validate_context_invalid_type PASSED                              [ 97%]
tests/unit_tests/test_ef_version.py::TestVersion::test_version_init PASSED                                                 [ 97%]
tests/unit_tests/test_ef_version.py::TestVersion::test_version_init_no_metadata PASSED                                     [ 98%]
tests/unit_tests/test_ef_version.py::TestEFVersionModule::test_cmd_rollback_latest_stable PASSED                           [ 98%]
tests/unit_tests/test_ef_version.py::TestEFVersionModule::test_cmd_rollback_to_ami PASSED                                  [ 99%]
tests/unit_tests/test_ef_version.py::TestEFVersionModule::test_cmd_rollback_to_unknown_ami PASSED                          [ 99%]
tests/unit_tests/test_ef_version_resolver.py::TestEFVersionResolver::test_ami_id PASSED                                    [100%]

---------- coverage: platform darwin, python 2.7.15-final-0 ----------
Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
efopen/ef_utils.py     148     19    87%   81-84, 107, 179-180, 212, 233-240, 283, 290-291, 309-310


============================================ 206 passed, 24 warnings in 0.98 seconds =============================================
```