### PR TITLE
OPS-13352 Make whereami aware of Jenkins

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -236,15 +236,16 @@ def main():
   parameter_file = parameter_file_dir + "/" + service_name + ".parameters." + context.env_full + ".json"
 
   # If running in EC2, use instance credentials (i.e. profile = None)
-  # otherwise, use local credentials with profile name in .aws/credentials == account alias name
-  if context.whereami == "ec2" and not os.getenv("JENKINS_URL", False):
+  # unless it's a Jenkins environment or non-EC2, which means that we use local
+  # credentials with profile name in .aws/credentials == account alias name
+  if context.whereami == "ec2":
     profile = None
   else:
     profile = context.account_alias
 
   # Get service registry and refresh repo if appropriate
   try:
-    if not (context.devel or os.getenv("JENKINS_URL", False)):
+    if not (context.devel or context.whereami != 'jenkins'):
       pull_repo()
     else:
       print("not refreshing repo because --devel was set or running on Jenkins")

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -30,7 +30,6 @@ limitations under the License.
 from __future__ import print_function
 import argparse
 import json
-from os import getenv
 from os.path import dirname, normpath
 import sys
 import time
@@ -547,7 +546,7 @@ def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER
 
   CONTEXT = handle_args_and_set_context(sys.argv[1:])
-  if not (CONTEXT.devel or getenv("JENKINS_URL", False)):
+  if not (CONTEXT.devel or CONTEXT.whereami != 'jenkins'):
     try:
       pull_repo()
     except RuntimeError as error:

--- a/efopen/ef_instanceinit.py
+++ b/efopen/ef_instanceinit.py
@@ -180,6 +180,8 @@ def main():
     critical("Cannot determine whether operating context is ec2 or local. Exiting.")
   elif WHERE == "local":
     critical("local mode not supported: must run under virtualbox-kvm or in ec2")
+  elif WHERE == 'jenkins':
+    critical("will not run inside a Jenkins environment")
   elif WHERE == "ec2":
     # get info needed for logging
     try:

--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -19,7 +19,7 @@ limitations under the License.
 from __future__ import print_function
 import base64
 import json
-from os import access, X_OK
+from os import access, getenv, X_OK
 from os.path import isfile
 import re
 from socket import gethostname
@@ -88,10 +88,14 @@ def whereami():
   Determine if this is an ec2 instance or "running locally"
   Returns:
     "ec2" - this is an ec2 instance
+    "jenkins" - running inside a Jenkins job
     "virtualbox-kvm" - kernel VM (virtualbox with vagrant)
     "local" - running locally and not in a known VM
     "unknown" - I have no idea where I am
   """
+  if getenv("JENKINS_URL"):
+    return "jenkins"
+
   # If the metadata endpoint responds, this is an EC2 instance
   # If it doesn't, we can safely say this isn't EC2 and try the other options
   try:

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -28,7 +28,6 @@ import argparse
 from inspect import isfunction
 import json
 from operator import itemgetter
-from os import getenv
 import sys
 import urllib2
 
@@ -710,7 +709,7 @@ def main():
   context = handle_args_and_set_context(sys.argv[1:])
 
   # Refresh from repo if necessary and possible (gets don't need service registry, sets do)
-  if (context.rollback or context.value) and not (context.devel or getenv("JENKINS_URL", False)):
+  if (context.rollback or context.value) and not (context.devel or context.whereami != 'jenkins'):
     print("Refreshing repo")
     try:
       pull_repo()

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -196,6 +196,29 @@ class TestEFUtils(unittest.TestCase):
     result = ef_utils.whereami()
     self.assertEquals(result, "ec2")
 
+  @patch('ef_utils.http_get_metadata')
+  @patch('ef_utils.getenv')
+  def test_whereami_jenkins(self, mock_http_get_metadata, mock_getenv):
+    """
+    Tests whereami to see if it returns 'jenkins' by mocking an ec2 Jenkins
+    environment
+
+    Args:
+      mock_http_get_metadata: MagicMock, returns "i-somestuff"
+      mock_get_env: MagicMock, mocks the environment variables
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    mock_http_get_metadata.return_value = "i-somestuff"
+    mock_getenv.return_value = "not-falsy"
+    result = ef_utils.whereami()
+    self.assertEquals(result, "jenkins")
+
+
   @patch('ef_utils.is_in_virtualbox')
   @patch('ef_utils.gethostname')
   @patch('ef_utils.http_get_metadata')


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
ef-open runs checks in multiple places if it is running inside an ec2 or not; if does, it uses the instance profile.
Jenkins needs to run commands on multiple environments and depends on a credential map defined in ef_site_config.yml. If we tell whereami about Jenkins, ef-open will try to follow the account map instead of blindly using instance credentials.
[OPS-13352](https://ellation.atlassian.net/browse/OPS-13352)
## Changelog
- whereami knows about Jenkins