### PR TITLE
Fix whereami tests

### DIFF
--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -94,7 +94,6 @@ def whereami():
     "unknown" - I have no idea where I am
   """
   if getenv("JENKINS_URL"):
-    print(getenv("JENKINS_URL"))
     return "jenkins"
 
   # If the metadata endpoint responds, this is an EC2 instance

--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -94,6 +94,7 @@ def whereami():
     "unknown" - I have no idea where I am
   """
   if getenv("JENKINS_URL"):
+    print(getenv("JENKINS_URL"))
     return "jenkins"
 
   # If the metadata endpoint responds, this is an EC2 instance

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -178,8 +178,9 @@ class TestEFUtils(unittest.TestCase):
       ef_utils.http_get_metadata("ami-id")
     self.assertIn("Non-200 response", exception.exception.message)
 
+  @patch('ef_utils.getenv')
   @patch('ef_utils.http_get_metadata')
-  def test_whereami_ec2(self, mock_http_get_metadata):
+  def test_whereami_ec2(self, mock_http_get_metadata, getenv):
     """
     Tests whereami to see if it returns 'ec2' by mocking an ec2 environment
 
@@ -193,11 +194,12 @@ class TestEFUtils(unittest.TestCase):
       AssertionError if any of the assert checks fail
     """
     mock_http_get_metadata.return_value = "i-somestuff"
+    getenv.return_value = False
     result = ef_utils.whereami()
     self.assertEquals(result, "ec2")
 
-  @patch('ef_utils.http_get_metadata')
   @patch('ef_utils.getenv')
+  @patch('ef_utils.http_get_metadata')
   def test_whereami_jenkins(self, mock_http_get_metadata, mock_getenv):
     """
     Tests whereami to see if it returns 'jenkins' by mocking an ec2 Jenkins
@@ -219,10 +221,12 @@ class TestEFUtils(unittest.TestCase):
     self.assertEquals(result, "jenkins")
 
 
+
+  @patch('ef_utils.getenv')
   @patch('ef_utils.is_in_virtualbox')
   @patch('ef_utils.gethostname')
   @patch('ef_utils.http_get_metadata')
-  def test_whereami_local(self, mock_http_get_metadata, mock_gethostname, mock_is_in_virtualbox):
+  def test_whereami_local(self, mock_http_get_metadata, mock_gethostname, mock_is_in_virtualbox, mock_getenv):
     """
     Tests whereami to see if it returns 'local' by mocking a local machine environment
 
@@ -236,16 +240,18 @@ class TestEFUtils(unittest.TestCase):
     Raises:
       AssertionError if any of the assert checks fail
     """
+    mock_getenv.return_value = False
     mock_http_get_metadata.return_value = "nothinguseful"
     mock_is_in_virtualbox.return_value = False
     mock_gethostname.return_value = ".local"
     result = ef_utils.whereami()
     self.assertEquals(result, "local")
 
+  @patch('ef_utils.getenv')
   @patch('ef_utils.is_in_virtualbox')
   @patch('ef_utils.gethostname')
   @patch('ef_utils.http_get_metadata')
-  def test_whereami_unknown(self, mock_http_get_metadata, mock_gethostname, mock_is_in_virtualbox):
+  def test_whereami_unknown(self, mock_http_get_metadata, mock_gethostname, mock_is_in_virtualbox, mock_getenv):
     """
     Tests whereami to see if it returns 'unknown' by mocking the environment to not match anything
 
@@ -259,6 +265,7 @@ class TestEFUtils(unittest.TestCase):
     Raises:
       AssertionError if any of the assert checks fail
     """
+    mock_getenv.return_value = False
     mock_http_get_metadata.return_value = "nothinguseful"
     mock_is_in_virtualbox.return_value = False
     mock_gethostname.return_value = "not local"


### PR DESCRIPTION
## Ready State
**Ready**
## Synopsis
The code changes in #128 failed to account for the CI running in Jenkins, generating a number of false negatives on the unit-test level. This PR fixes that.

https://jenkins-build.ellationeng.cx-mgmt.com/job/ef-open/242/console
## Changelog
- override the Jenkins environment in tests