### PR TITLE
OPS-13555 Fix ef-version rollback logic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,14 @@
-## Ready State
+# Ready State and Ticket
 > Valid states are:
 > Ready - This PR is ready to be reviewed.
-> Not Ready - Please provide an explanation.
+> Not Ready - Please provide an explanation below.
 **Ready**
-## Synopsis
-> Include a brief description of the overall point of this PR and a link to the ticket.
-[OPS-XXXX](https://ellation.atlassian.net/browse/OPS-XXXX)
-## Changelog
-> Brief summary of changes which should be included in your commit messages.
-## Dependencies
-> List any items which need to be in place for this review, such as which machines must running or any software 
-> packages needed.
-## Linked PRs
-> Include links to any other PRs that are related to this one.
-## Testing
-> Include instructions for testing this PR.  The format of this should be numbered bullets (use `1.` for each bullet
-> in your markdown) with sub-bullets for assertions.  Bug fixes should 
-> contain instructions for confirming the bug before confirming the fix.  Please include screenshots and explanations 
-> of jargon where appropriate.
-1. Example testing instruction: Load some page.
-  * Assert the HTTP status is 200.
-  * Assert the body of the response contains some text.
-1. A second example step.
-###### [Markdown support](https://guides.github.com/features/mastering-markdown/)
+[OPS-XXXXX](https://ellation.atlassian.net/browse/OPS-XXXXX)
+
+# Details
+> A description of the motivation and implementation of this PR.
+> Include any relevant details like:
+> - Test results
+> - Unusual deployment requirements
+> - Current deployed state, if any
+> - General issues for discussion during the review

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -521,7 +521,6 @@ def get_versions(context, return_stable=False):
     return []
   object_versions = []
   for version in object_version_list["Versions"]:
-
     object_version = Version(context.aws_client("s3").get_object(
         Bucket=EFConfig.S3_VERSION_BUCKET,
         Key=s3_key,


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Fix the logic so that when a rollback is called and it's looking for stable versions, it will rollback to a previous stable build instead of to itself.
[OPS-13555](https://ellation.atlassian.net/browse/OPS-13555)

## Testing
Ran unit tests, they look fine but it's not the real thing
