### PR TITLE
OPS-13555 Update rollback logic for ef-version

### DIFF
--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -363,7 +363,7 @@ class TestEFVersionModule(unittest.TestCase):
 
   @patch('ef_version.cmd_set')
   @patch('ef_version.get_versions')
-  def test_cmd_rollback_latest_stable(self, get_versions, cmd_set):
+  def test_cmd_rollback_latest_stable(self, mock_get_versions, mock_cmd_set):
     '''Test cmd_rollback to the latest stable version'''
     context = Mock(ef_version.EFVersionContext)
     context.env = "alpha0"
@@ -372,18 +372,18 @@ class TestEFVersionModule(unittest.TestCase):
     context.service_name = "playheads"
     context.rollback = True
 
-    latest_stable = self.versions[0]
-    get_versions.return_value = [latest_stable]
+    rollback_stable_target = self.versions[3]
+    mock_get_versions.return_value = self.versions
 
     ef_version.cmd_rollback(context)
     self.assertEqual(context.stable, True)
-    self.assertEqual(context.value, latest_stable.value)
-    self.assertEqual(context.build_number, latest_stable.build_number)
-    self.assertEqual(context.commit_hash, latest_stable.commit_hash)
-    self.assertEqual(context.location, latest_stable.location)
+    self.assertEqual(context.value, rollback_stable_target.value)
+    self.assertEqual(context.build_number, rollback_stable_target.build_number)
+    self.assertEqual(context.commit_hash, rollback_stable_target.commit_hash)
+    self.assertEqual(context.location, rollback_stable_target.location)
 
-    get_versions.assert_called_once_with(context, return_stable=True)
-    cmd_set.assert_called_once_with(context)
+    mock_get_versions.assert_called_with(context)
+    mock_cmd_set.assert_called_once_with(context)
 
   @patch('ef_version.cmd_set')
   @patch('ef_version.get_versions')


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Corrected logic for rollback in the scenario of qa deploys and rolling back from a stable deploy
[OPS-13555](https://ellation.atlassian.net/browse/OPS-13555)

## Testing
Ran unit tests

000460-ml:ellation_formation vfang$ ef-version --history text test-instance ami-id staging
staging-test-instance ami-id
ami-0dec43a8ae0965b7f 56 test-instance=fb64f9486ab13df6cf482bde328fb45b1b4dd211,pipeline=ab8b9aebd22e8cdf454fa8bc2e3412177e614de0 2019-09-06T23:57:24UTC arn:aws:sts::366843697376:assumed-role/global-role-devops-team/botocore-session-1567814234 1f0Bq_ptpNX..xHHZweR_IExxksvYF4p  stable
ami-03691cfbb177fc240 57 test-instance=0031fce3a33d324946cfaf4ac1fcac6c194e5bd9,pipeline=ab8b9aebd22e8cdf454fa8bc2e3412177e614de0 2019-09-06T07:46:47UTC arn:aws:iam::366843697376:user/vfang 0_FXGAzVQlekKWOnaxLSsHN2YChSQ7q.  stable
ami-03691cfbb177fc240 57 test-instance=0031fce3a33d324946cfaf4ac1fcac6c194e5bd9,pipeline=ab8b9aebd22e8cdf454fa8bc2e3412177e614de0 2019-09-06T07:41:16UTC arn:aws:iam::366843697376:user/vfang Wdf3cigJtnYrf6279rTgm0CXgz6Uin7o  undefined
ami-0dec43a8ae0965b7f 56 test-instance=fb64f9486ab13df6cf482bde328fb45b1b4dd211,pipeline=ab8b9aebd22e8cdf454fa8bc2e3412177e614de0 2019-09-06T07:08:02UTC arn:aws:iam::366843697376:user/vfang uLtHbBAEjjib3vIiXCiHCQ5GzcYxPkSG  stable
ami-0dec43a8ae0965b7f 56 test-instance=fb64f9486ab13df6cf482bde328fb45b1b4dd211,pipeline=ab8b9aebd22e8cdf454fa8bc2e3412177e614de0 2019-09-06T07:02:07UTC arn:aws:iam::366843697376:user/vfang ul7YocdAMa2iLaoDLVHd0j4lTTiGUcvr  undefined
ami-09cdc8624f3de17e1 55 test-instance=fb64f9486ab13df6cf482bde328fb45b1b4dd211,pipeline=ab8b9aebd22e8cdf454fa8bc2e3412177e614de0 2019-09-06T06:58:58UTC arn:aws:iam::366843697376:user/vfang djPAyIzj1qgNwwmP4Xs381VBIdZ8aKdi  stable
