### PR TITLE
OPS-13631 Fix logic so that ef-open tools behave correctly on Jenkins and elsewhere

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -236,7 +236,7 @@ def main():
   parameter_file = parameter_file_dir + "/" + service_name + ".parameters." + context.env_full + ".json"
 
   # If running in EC2, use instance credentials (i.e. profile = None)
-  # unless it's a Jenkins environment or non-EC2, which means that we use local
+  # unless it's a non-EC2, which means that we use local
   # credentials with profile name in .aws/credentials == account alias name
   if context.whereami == "ec2":
     profile = None
@@ -245,7 +245,7 @@ def main():
 
   # Get service registry and refresh repo if appropriate
   try:
-    if not (context.devel or context.whereami != 'jenkins'):
+    if not context.devel and context.whereami != 'jenkins':
       pull_repo()
     else:
       print("not refreshing repo because --devel was set or running on Jenkins")

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -546,7 +546,8 @@ def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER
 
   CONTEXT = handle_args_and_set_context(sys.argv[1:])
-  if not (CONTEXT.devel or CONTEXT.whereami != 'jenkins'):
+  #if not (CONTEXT.devel or CONTEXT.whereami != 'jenkins'):
+  if not CONTEXT.devel and CONTEXT.whereami != 'jenkins':
     try:
       pull_repo()
     except RuntimeError as error:

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -546,7 +546,6 @@ def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER
 
   CONTEXT = handle_args_and_set_context(sys.argv[1:])
-  #if not (CONTEXT.devel or CONTEXT.whereami != 'jenkins'):
   if not CONTEXT.devel and CONTEXT.whereami != 'jenkins':
     try:
       pull_repo()

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -734,12 +734,14 @@ def main():
   context = handle_args_and_set_context(sys.argv[1:])
 
   # Refresh from repo if necessary and possible (gets don't need service registry, sets do)
-  if (context.rollback or context.value) and not (context.devel or context.whereami != 'jenkins'):
+  if (context.rollback or context.value) and (not context.devel and context.whereami != 'jenkins'):
     print("Refreshing repo")
     try:
       pull_repo()
     except RuntimeError as error:
       fail("Error checking or pulling repo", error)
+  else:
+    print("Not refreshing repo because --devel was set or running on Jenkins")
 
   # Sign on to AWS and create clients
   if context.whereami in ["ec2"]:


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-13631](https://ellation.atlassian.net/browse/OPS-13631)

# Details
Unexpected behavior occurred when we pushed out ef-open release 0.13.5. This PR aims to fix the issues with the whereami jenkins introduced as well as clear up the hard to read conditions

Tested ef-cf, ef-generate, ef-version on my machine using PyCharm to mimic that it's a Jenkins Machine with the JENKINS_URL env var
