### PR TITLE
OPS-13637 Fix ef-open to work with docker

### DIFF
--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -93,7 +93,11 @@ def whereami():
     "local" - running locally and not in a known VM
     "unknown" - I have no idea where I am
   """
-  if getenv("JENKINS_URL"):
+  if getenv("JENKINS_URL") and getenv("JENKINS_DOCKER") is None:
+    # The addition of the JENKINS_DOCKER is a temporary workaround to have Jenkins Docker machine rely on its instance
+    # role and assume roles vs a credentials file. This is an on-going effort to move everything to code with
+    # https://ellation.atlassian.net/browse/OPS-13637
+    # Regular Jenkins machines will still continue to use their credentials files until we switch over.
     return "jenkins"
 
   # If the metadata endpoint responds, this is an EC2 instance

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -217,11 +217,12 @@ class TestEFUtils(unittest.TestCase):
     """
     mock_http_get_metadata.return_value = "i-somestuff"
 
-    def getenv_side_effect(*args, **kwargs):
-      if args[0] == "JENKINS_URL":
+    def getenv_side_effect(key, default=None):
+      if key == "JENKINS_URL":
         return True
-      if args[0] == "JENKINS_DOCKER":
+      if key == "JENKINS_DOCKER":
         return None
+      return default
     mock_getenv.side_effect = getenv_side_effect
     result = ef_utils.whereami()
     self.assertEquals(result, "jenkins")
@@ -244,11 +245,12 @@ class TestEFUtils(unittest.TestCase):
       AssertionError if any of the assert checks fail
     """
     mock_http_get_metadata.return_value = "i-somestuff"
-    def getenv_side_effect(*args, **kwargs):
-      if args[0] == "JENKINS_URL":
+    def getenv_side_effect(key, default=None):
+      if key == "JENKINS_URL":
         return True
-      if args[0] == "JENKINS_DOCKER":
+      if key == "JENKINS_DOCKER":
         return True
+      return default
     mock_getenv.side_effect = getenv_side_effect
     result = ef_utils.whereami()
     self.assertEquals(result, "ec2")

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -216,11 +216,42 @@ class TestEFUtils(unittest.TestCase):
       AssertionError if any of the assert checks fail
     """
     mock_http_get_metadata.return_value = "i-somestuff"
-    mock_getenv.return_value = "not-falsy"
+
+    def getenv_side_effect(*args, **kwargs):
+      if args[0] == "JENKINS_URL":
+        return True
+      if args[0] == "JENKINS_DOCKER":
+        return None
+    mock_getenv.side_effect = getenv_side_effect
     result = ef_utils.whereami()
     self.assertEquals(result, "jenkins")
 
+  @patch('ef_utils.getenv')
+  @patch('ef_utils.http_get_metadata')
+  def test_whereami_jenkins_docker(self, mock_http_get_metadata, mock_getenv):
+    """
+    Tests whereami to see if it returns 'ec2' by mocking an ec2 Jenkins Docker
+    environment
 
+    Args:
+      mock_http_get_metadata: MagicMock, returns "i-somestuff"
+      mock_get_env: MagicMock, mocks the environment variables
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    mock_http_get_metadata.return_value = "i-somestuff"
+    def getenv_side_effect(*args, **kwargs):
+      if args[0] == "JENKINS_URL":
+        return True
+      if args[0] == "JENKINS_DOCKER":
+        return True
+    mock_getenv.side_effect = getenv_side_effect
+    result = ef_utils.whereami()
+    self.assertEquals(result, "ec2")
 
   @patch('ef_utils.getenv')
   @patch('ef_utils.is_in_virtualbox')


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-13637](https://ellation.atlassian.net/browse/OPS-13637)

# Details
Update ef-open so that it still looks for a credentials file on regular jenkins and instance role on jenkins docker
