### PR TITLE
allow managed job functions to be used in the aws_managed_policies array

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -34,6 +34,7 @@ from os.path import dirname, normpath
 import sys
 import time
 
+import botocore
 from botocore.exceptions import ClientError
 
 from ef_aws_resolver import EFAwsResolver
@@ -360,6 +361,11 @@ def conditionally_attach_aws_managed_policies(role_name, sr_entry):
     if CONTEXT.commit:
       try:
         CLIENTS["iam"].attach_role_policy(RoleName=role_name, PolicyArn='arn:aws:iam::aws:policy/' + policy_name)
+        print_if_verbose("Attached managed policy '{}'".format(policy_name))
+      except CLIENTS["iam"].exceptions.NoSuchEntityException:
+        CLIENTS["iam"].attach_role_policy(RoleName=role_name,
+                                          PolicyArn='arn:aws:iam::aws:policy/job-function/' + policy_name)
+        print_if_verbose("Attached managed job-function '{}'".format(policy_name))
       except:
         fail("Exception putting policy: {} onto role: {}".format(policy_name, role_name), sys.exc_info())
 


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
# Details
allow managed job functions to be used in the aws_managed_policies array

![Screen Shot 2019-09-25 at 4 19 14 PM](https://user-images.githubusercontent.com/7519487/65646697-c5f64500-dfb0-11e9-9b80-a2ff4196c686.png)

![Screen Shot 2019-09-25 at 4 19 26 PM](https://user-images.githubusercontent.com/7519487/65646704-c989cc00-dfb0-11e9-94b6-b8a9be2baec8.png)

```
± |master {2} U:1 ✗| → python2 ../ef-open/efopen/ef_generate.py global.ellationeng --commit --verbose
Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
env: global
env_full: global.ellationeng
env_short: global
aws account profile: ellationeng
aws account number: 366843697376
service: role-sto-standard-access-etpv1 in env: global
Load policy: assume_role_trust_ellationiam from file: /Users/dlutsch/workspace/ellation_formation/policy_templates/assume_role_trust_ellationiam.json
pre-resolution policy template:
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::190231206472:root"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}

{'INSTANCE_ID': None, 'ACCOUNT': '366843697376', 'ROLE': None, 'SERVICE': (u'role-sto-standard-access-etpv1', {u'team_email': u'ops@ellation.com', u'runbook_url': u'TBD', u'aws_managed_policies': [u'ViewOnlyAccess'], u'description': u'Standardized STO access for ETPv1', u'environments': [u'global.codemobs', u'global.ellationeng', u'global.ellation'], u'assume_role_policy': u'assume_role_trust_ellationiam', u'policies': [u'policy-sto-standard-access-ellationeng'], u'type': u'aws_role'}), 'ENV': 'global', 'ACCOUNT_ALIAS': 'ellationeng', 'REGION': 'us-west-2', 'ENV_FULL': 'global.ellationeng', 'FUNCTION_NAME': None, 'ENV_SHORT': 'global'}
resolved policy document:
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::190231206472:root"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}

role already exists: global-role-sto-standard-access-etpv1
not eligible for kms; service_type: aws_role is not valid for kms
loading policy: ViewOnlyAccess for role: global-role-sto-standard-access-etpv1
Attached managed job-function 'ViewOnlyAccess'
```
