### PR TITLE
Remove Exception.message attribute access

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -128,7 +128,7 @@ def handle_args_and_set_context(args):
     context.env = parsed_args["env"]
     context.template_file = parsed_args["template_file"]
   except ValueError as e:
-    fail("Error in argument: {}".format(e.message))
+    fail("Error in argument: {}".format(e))
   context.changeset = parsed_args["changeset"]
   context.commit = parsed_args["commit"]
   context.devel = parsed_args["devel"]

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -128,7 +128,7 @@ def handle_args_and_set_context(args):
   try:
     context.env = parsed_args["env"]
   except ValueError as e:
-    fail("Error in env: {}".format(e.message))
+    fail("Error in env: {}".format(e))
   # Set up service registry and policy template path which depends on it
   context.service_registry = EFServiceRegistry(parsed_args["sr"])
   context.policy_template_path = normpath(dirname(context.service_registry.filespec)) + EFConfig.POLICY_TEMPLATE_PATH_SUFFIX

--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -169,7 +169,7 @@ def handle_args_and_set_context(args):
   try:
     context.env = parsed_args["env"]
   except ValueError as e:
-    ef_utils.fail("Error in env: {}".format(e.message))
+    ef_utils.fail("Error in env: {}".format(e))
   context.service = parsed_args["service"]
   context.decrypt = parsed_args["decrypt"]
   context.length = parsed_args["length"]

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -305,7 +305,7 @@ def handle_args_and_set_context(args):
   try:
     context.env = parsed_args["env"]
   except ValueError as e:
-    fail("Error in env: {}".format(e.message))
+    fail("Error in env: {}".format(e))
   # marshall this module's additional context values
   context._get = parsed_args["get"]
   context._history = parsed_args["history"]
@@ -686,7 +686,7 @@ def cmd_set(context):
   try:
     precheck(context)
   except Exception as e:
-    fail("Precheck failed: {}".format(e.message))
+    fail("Precheck failed: {}".format(e))
 
   s3_key = "{}/{}/{}".format(context.service_name, context.env, context.key)
   s3_version_status = EFConfig.S3_VERSION_STATUS_STABLE if context.stable else EFConfig.S3_VERSION_STATUS_UNDEFINED

--- a/efopen/ef_version_resolver.py
+++ b/efopen/ef_version_resolver.py
@@ -81,7 +81,7 @@ class EFVersionResolver(object):
     try:
       env, service = envservice.split("/")
     except ValueError as e:
-      raise RuntimeError("Request:{} can't resolve to env, service. {}".format(envservice, e.message))
+      raise RuntimeError("Request:{} can't resolve to env, service. {}".format(envservice, e))
 
     return self._s3_get(env, service, key)
 

--- a/efopen/test-template.txt
+++ b/efopen/test-template.txt
@@ -1,0 +1,10 @@
+{{aws:ec2:security-group/security-group-id,{{ENV}}-playheads-ec2}}
+{{aws:acm:certificate-arn,us-east-1/cx-{{ENV}}.com}}
+{{aws:acm:certificate-arn,{{REGION}}/cx-{{ENV}}.com}}
+{{aws:cloudfront:domain-name,cx-proto0.com}}
+{{aws:cognito-identity:identity-pool-arn,proto0_cms_identity_pool,NONE}}
+{{aws:cognito-identity:identity-pool-id,proto0_cms_identity_pool,NONE}}
+{{aws:cognito-idp:user-pool-arn,proto0-cognito-config-delta,NONE}}
+{{aws:cognito-idp:user-pool-id,proto0-cms-user-pool}}
+{{aws:ec2:elasticip/elasticip-id,ElasticIpMgmtJenkins1}}
+{{aws:ec2:elasticip/elasticip-ipaddress,ElasticIpMgmtJenkins1}}

--- a/tests/unit_tests/test_ef_conf_utils.py
+++ b/tests/unit_tests/test_ef_conf_utils.py
@@ -82,21 +82,21 @@ class TestEFConfUtils(unittest.TestCase):
         continue
       with self.assertRaises(ValueError) as exception:
         ef_conf_utils.global_env_valid(env)
-      self.assertTrue("Invalid global env" in exception.exception.message)
+      self.assertIn("Invalid global env", str(exception.exception))
 
     # Hard coded junk values
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.global_env_valid("not_global")
-    self.assertTrue("Invalid global env" in exception.exception.message)
+    self.assertIn("Invalid global env", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.global_env_valid("not_mgmt")
-    self.assertTrue("Invalid global env" in exception.exception.message)
+    self.assertIn("Invalid global env", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.global_env_valid("")
-    self.assertTrue("Invalid global env" in exception.exception.message)
+    self.assertIn("Invalid global env", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.global_env_valid(None)
-    self.assertTrue("Invalid global env" in exception.exception.message)
+    self.assertIn("Invalid global env", str(exception.exception))
 
   def test_env_valid(self):
     """
@@ -326,23 +326,23 @@ class TestEFConfUtils(unittest.TestCase):
         env += '0'
       with self.assertRaises(ValueError) as exception:
         ef_conf_utils.get_account_alias(env)
-      self.assertTrue("unknown env" in exception.exception.message)
+      self.assertIn("unknown env", str(exception.exception))
 
     # Hard coded junk values
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.get_account_alias("non-existent-env")
-    self.assertTrue("unknown env" in exception.exception.message)
+    self.assertIn("unknown env", str(exception.exception))
     with patch('ef_conf_utils.env_valid') as mock_env_valid:
       with self.assertRaises(ValueError) as exception:
         mock_env_valid.return_value = True
         ef_conf_utils.get_account_alias("non-existent-env")
-    self.assertTrue("has no entry in ENV_ACCOUNT_MAP" in exception.exception.message)
+    self.assertIn("has no entry in ENV_ACCOUNT_MAP", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.get_account_alias("")
-    self.assertTrue("unknown env" in exception.exception.message)
+    self.assertIn("unknown env", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.get_account_alias(None)
-    self.assertTrue("unknown env" in exception.exception.message)
+    self.assertIn("unknown env", str(exception.exception))
 
   def test_get_template_parameters_s3(self):
     """Test method returns valid parameters file"""
@@ -388,15 +388,15 @@ class TestEFConfUtils(unittest.TestCase):
         env += '0'
       with self.assertRaises(ValueError) as exception:
         ef_conf_utils.get_env_short(env)
-      self.assertTrue("unknown env" in exception.exception.message)
+      self.assertIn("unknown env", str(exception.exception))
 
     # Hard coded junk values
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.get_env_short("non-existent-env")
-    self.assertTrue("unknown env" in exception.exception.message)
+    self.assertIn("unknown env", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.get_env_short("")
-    self.assertTrue("unknown env" in exception.exception.message)
+    self.assertIn("unknown env", str(exception.exception))
     with self.assertRaises(ValueError) as exception:
       ef_conf_utils.get_env_short(None)
-    self.assertTrue("unknown env" in exception.exception.message)
+    self.assertIn("unknown env", str(exception.exception))

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -176,7 +176,7 @@ class TestEFUtils(unittest.TestCase):
     mock_urllib2.return_value = mock_response
     with self.assertRaises(IOError) as exception:
       ef_utils.http_get_metadata("ami-id")
-    self.assertIn("Non-200 response", exception.exception.message)
+    self.assertIn("Non-200 response", str(exception.exception))
 
   @patch('ef_utils.getenv')
   @patch('ef_utils.http_get_metadata')
@@ -340,7 +340,7 @@ class TestEFUtils(unittest.TestCase):
     mock_http_get_metadata.return_value = "No data"
     with self.assertRaises(Exception) as exception:
       ef_utils.http_get_instance_env()
-    self.assertIn("Error looking up metadata:iam/info", exception.exception.message)
+    self.assertIn("Error looking up metadata:iam/info", str(exception.exception))
 
   @patch('ef_utils.http_get_metadata')
   def test_http_get_instance_role(self, mock_http_get_metadata):
@@ -377,7 +377,7 @@ class TestEFUtils(unittest.TestCase):
     mock_http_get_metadata.return_value = "No data"
     with self.assertRaises(Exception) as exception:
       ef_utils.http_get_instance_role()
-    self.assertIn("Error looking up metadata:iam/info:", exception.exception.message)
+    self.assertIn("Error looking up metadata:iam/info:", str(exception.exception))
 
   @patch('ef_utils.http_get_metadata')
   def test_get_instance_aws_context(self, mock_http_get_metadata):
@@ -436,7 +436,7 @@ class TestEFUtils(unittest.TestCase):
     mock_ec2_client = Mock(name="mock-ec2-client")
     with self.assertRaises(IOError) as exception:
       ef_utils.get_instance_aws_context(mock_ec2_client)
-    self.assertIn("Error looking up metadata:availability-zone or instance-id:", exception.exception.message)
+    self.assertIn("Error looking up metadata:availability-zone or instance-id:", str(exception.exception))
 
   @patch('boto3.Session')
   def test_create_aws_clients(self, mock_session_constructor):

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -439,7 +439,6 @@ class TestEFVersionModule(unittest.TestCase):
 
     with self.assertRaises(SystemExit) as e:
       ef_version.cmd_rollback_to(context)
-      self.assertIn(ami_id, e.message)
 
     get_versions.assert_called_once_with(context)
     cmd_set.assert_not_called()


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
The `message` attribute on the Exception classes was deprecated in Python 2.5 and removed completely for Python 3. In order to port to Py3, we need to get rid of any Exception.message calls.
