### PR TITLE
Add a travis.ci file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
     - "2.7"
 
 install:
-    python setup.py test
+    pip install -p
 script:
     python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+    - "2.7"
+
+install:
+    python setup.py test
+script:
+    python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - "2.7"
 
 install:
-    pip install -p
+    - python setup.py install
+    - python setup.py test
 script:
     python -m unittest discover


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
We're not running any CI on ef-open since it's a public repo and anybody can botch our Jenkins pipelines. Why not make us of Travis, which allows free CI for open source project?

We need to setup a Travis.ci account, but the rest is quite simple.

e.g: https://travis-ci.com/momoneko/ef-open