### PR TITLE
Refactor has_key method calls

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -98,7 +98,7 @@ class EFAwsResolver(object):
       if cert_handle["DomainName"] == domain_name:
         cert = acm_client.describe_certificate(CertificateArn=cert_handle["CertificateArn"])["Certificate"]
         # Patch up cert if there is no IssuedAt (i.e. cert was not issued by Amazon)
-        if not cert.has_key("IssuedAt"):
+        if "IssuedAt" not in cert:
           cert[u"IssuedAt"] = datetime.datetime(1970, 1, 1, 0, 0)
         if best_match_cert is None:
           best_match_cert = cert
@@ -403,7 +403,7 @@ class EFAwsResolver(object):
       for rule in rules["Rules"]:
         if rule["Name"] == lookup:
           return rule["RuleId"]
-      if rules.has_key("NextMarker"):
+      if "NextMarker" in rules:
         rules = EFAwsResolver.__CLIENTS["waf"].list_rules(Limit=list_limit, NextMarker=rules["NextMarker"])
       else:
         return default
@@ -423,7 +423,7 @@ class EFAwsResolver(object):
       for acl in acls["WebACLs"]:
         if acl["Name"] == lookup:
           return acl["WebACLId"]
-      if acls.has_key("NextMarker"):
+      if "NextMarker" in acls:
         acls = EFAwsResolver.__CLIENTS["waf"].list_web_acls(Limit=list_limit, NextMarker=acls["NextMarker"])
       else:
         return default
@@ -442,7 +442,7 @@ class EFAwsResolver(object):
       return default
     hosted_zones = EFAwsResolver.__CLIENTS["route53"].list_hosted_zones_by_name(DNSName=lookup, MaxItems=list_limit)
     # Return if the account has no HostedZones
-    if not hosted_zones.has_key("HostedZones"):
+    if "HostedZones" not in hosted_zones:
       return default
     while True:
       for hosted_zone in hosted_zones["HostedZones"]:
@@ -468,7 +468,7 @@ class EFAwsResolver(object):
       return default
     hosted_zones = EFAwsResolver.__CLIENTS["route53"].list_hosted_zones_by_name(DNSName=lookup, MaxItems=list_limit)
     # Return if the account has no HostedZones
-    if not hosted_zones.has_key("HostedZones"):
+    if "HostedZones" not in hosted_zones:
       return default
     while True:
       for hosted_zone in hosted_zones["HostedZones"]:
@@ -527,7 +527,7 @@ class EFAwsResolver(object):
     list_limit = "100"
     distributions = EFAwsResolver.__CLIENTS["cloudfront"].list_distributions(MaxItems=list_limit)["DistributionList"]
     # Return if the account has no Distributions
-    if not distributions.has_key("Items"):
+    if "Items" not in distributions:
       return default
     while True:
       for distribution in distributions["Items"]:
@@ -552,7 +552,7 @@ class EFAwsResolver(object):
     oais = EFAwsResolver.__CLIENTS["cloudfront"].list_cloud_front_origin_access_identities(
       MaxItems=list_limit)["CloudFrontOriginAccessIdentityList"]
     # Return if the account has no OriginAccessIdentities
-    if not oais.has_key("Items"):
+    if "Items" not in oais:
       return default
     while True:
       for oai in oais["Items"]:
@@ -577,7 +577,7 @@ class EFAwsResolver(object):
     oais = EFAwsResolver.__CLIENTS["cloudfront"].list_cloud_front_origin_access_identities(
       MaxItems=list_limit)["CloudFrontOriginAccessIdentityList"]
     # Return if the account has no OriginAccessIdentities
-    if not oais.has_key("Items"):
+    if "Items" not in oais:
       return default
     while True:
       for oai in oais["Items"]:
@@ -627,7 +627,7 @@ class EFAwsResolver(object):
           return pool["IdentityPoolId"]
 
       # No match found on this page, but there are more pages
-      if response.has_key("NextToken"):
+      if "NextToken" in response:
         response = client.list_identity_pools(MaxResults=list_limit, NextToken=response["NextToken"])
       else:
         break
@@ -650,7 +650,7 @@ class EFAwsResolver(object):
 
     response = client.describe_user_pool(UserPoolId=user_pool_id)
 
-    if not response.has_key("UserPool"):
+    if "UserPool" not in response:
       return default
 
     return response["UserPool"]["Arn"]
@@ -676,7 +676,7 @@ class EFAwsResolver(object):
           return pool["Id"]
 
       # No match found on this page, but there are more pages
-      if response.has_key("NextToken"):
+      if "NextToken" in response:
         response = client.list_identity_pools(MaxResults=list_limit, NextToken=response["NextToken"])
       else:
         break

--- a/efopen/ef_context.py
+++ b/efopen/ef_context.py
@@ -153,7 +153,7 @@ class EFContext(object):
     """
     if client_id is None:
       return self._aws_clients
-    elif self._aws_clients is not None and self._aws_clients.has_key(client_id):
+    elif self._aws_clients is not None and client_id in self._aws_clients:
       return self._aws_clients[client_id]
     else:
       return None

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -279,7 +279,7 @@ def conditionally_create_role(role_name, sr_entry):
     print_if_verbose("not eligible for role (and possibly instance profile); service type: {}".format(service_type))
     return
 
-  if sr_entry.has_key("assume_role_policy"):
+  if "assume_role_policy" in sr_entry:
     # Explicitly defined AssumeRole policy
     assume_role_policy_document = resolve_policy_document(sr_entry["assume_role_policy"])
   else:

--- a/efopen/ef_service_registry.py
+++ b/efopen/ef_service_registry.py
@@ -57,7 +57,7 @@ class EFServiceRegistry(object):
     # Validate service registry
     # 1. All service groups listed in EFConfig.SERVICE_GROUPS must be present
     for service_group in EFConfig.SERVICE_GROUPS:
-      if not self.service_registry_json.has_key(service_group):
+      if service_group not in self.service_registry_json:
         raise RuntimeError("service registry: {} doesn't have '{}' service group listed in EFConfig".format(
                            self._service_registry_file, service_group))
     # 2. A service name must be unique and can only belong to one group
@@ -110,9 +110,9 @@ class EFServiceRegistry(object):
       if service_group not in EFConfig.SERVICE_GROUPS:
         raise RuntimeError("service registry: {} doesn't have '{}' section listed in EFConfig".format(
           self._service_registry_file, service_group))
-      return self.service_registry_json[service_group].iteritems()
+      return iter(self.service_registry_json[service_group].items())
     else:
-      return self.services().iteritems()
+      return iter(self.services().items())
 
   def _expand_ephemeral_env_names(self, envlist):
     """
@@ -143,7 +143,7 @@ class EFServiceRegistry(object):
       raise RuntimeError("service registry doesn't have service: {}".format(service_name))
 
     # Return empty list if service has no "environments" section
-    if not service_record.has_key("environments"):
+    if "environments" not in service_record:
       return []
     # Otherwise gather up the envs
     return self._expand_ephemeral_env_names(service_record["environments"])
@@ -167,7 +167,7 @@ class EFServiceRegistry(object):
     if service_record is None:
       raise RuntimeError("service registry doesn't have service: {}".format(service_name))
 
-    if not service_record.has_key("auto_deploy_environments"):
+    if "auto_deploy_environments" not in service_record:
       return []
 
     # The list of valid deployment environments, for this service
@@ -191,7 +191,7 @@ class EFServiceRegistry(object):
     Returns:
       the entire service record from the service registry or None if the record was not found
     """
-    if not self.services().has_key(service_name):
+    if service_name not in self.services():
       return None
     return self.services()[service_name]
 
@@ -203,7 +203,7 @@ class EFServiceRegistry(object):
       the name of the group the service is in, or None of the service was not found
     """
     for group in EFConfig.SERVICE_GROUPS:
-      if self.services(group).has_key(service_name):
+      if service_name in self.services(group):
         return group
     return None
 
@@ -214,7 +214,7 @@ class EFServiceRegistry(object):
     Returns:
       the region the service is in, or EFConfig.DEFAULT_REGION if the region was not found
     """
-    if not self.services()[service_name].has_key("region"):
+    if "region" not in self.services()[service_name]:
       return EFConfig.DEFAULT_REGION
     else:
       return self.services()[service_name]["region"]
@@ -232,9 +232,9 @@ class EFServiceRegistry(object):
     Raises:
       ValueError if the key was not found
     """
-    if not self.version_keys().has_key(version_key_name):
+    if version_key_name not in self.version_keys():
       raise RuntimeError("service registry doesn't have a version key entry for: {}".format(version_key_name))
-    if not self.version_keys()[version_key_name].has_key("allow_latest"):
+    if "allow_latest" not in self.version_keys()[version_key_name]:
       raise RuntimeError("service registry key {} doesn't have an 'allow_latest' value".format(
         version_key_name))
     return self.version_keys()[version_key_name]["allow_latest"]


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
`dict.has_key(x)` is being discouraged since [PEP-290](https://www.python.org/dev/peps/pep-0290/#testing-dictionary-membership) and removed in Python 3 completely in favour of `x in dict` - https://docs.python.org/3.0/whatsnew/3.0.html#builtins
