### PR TITLE
Update EFTemplateResolver Symbol Matching

### DIFF
--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -443,14 +443,15 @@ class EFTemplateResolver(object):
         # if symbol was resolved, replace it everywhere
         if resolved_symbol is not None:
           if isinstance(resolved_symbol, list):
-            self.template = self.template.replace("{{" + symbol + "}}", "\n".join(resolved_symbol))
+            # Using old style of string formatting here due to str.format() interaction with curly braces
+            self.template = re.sub(r'{{\.?%s}}' % re.escape(symbol), "\n".join(resolved_symbol), self.template)
           else:
-            self.template = self.template.replace("{{" + symbol + "}}", resolved_symbol)
+            self.template = re.sub(r'{{\.?%s}}' % re.escape(symbol), resolved_symbol, self.template)
           go_again = True
     return self.template
 
   def unresolved_symbols(self):
-    return set(re.findall(SYMBOL_PATTERN, self.template))
+    return set(symbol_pattern.findall(self.template))
 
   def count_braces(self):
     """

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -28,11 +28,10 @@ from ef_config_resolver import EFConfigResolver
 from ef_utils import create_aws_clients, fail, get_account_id, http_get_metadata, whereami
 from ef_version_resolver import EFVersionResolver
 
-# CONSTANTS
 # pattern to find resolvable symbols - finds innermost nestings
-SYMBOL_PATTERN = r'{{([0-9A-Za-z/_,.:\-\+=\*]+?)}}'
+symbol_pattern = re.compile(r'{{\.?([0-9A-Za-z/_,.:\-+=*]+?)}}')
 # inverse of SYMBOL_PATTERN, and disallows ':' and ',' from param keys; this is checked in load()
-ILLEGAL_PARAMETER_CHARS = r'[^(0-9A-Za-z/_.\-)]'
+illegal_param_chars = re.compile(r'[^(0-9A-Za-z/_\-)]')
 
 
 # Utilities
@@ -371,7 +370,7 @@ class EFTemplateResolver(object):
       self.parameters = self.parameters["params"]
       # are all the keys valid (must have legal characters)
       for k in set().union(*(self.parameters[d].keys() for d in self.parameters.keys())):
-        invalid_char = re.search(ILLEGAL_PARAMETER_CHARS, k)
+        invalid_char = illegal_param_chars.search(k)
         if invalid_char:
           fail("illegal character: '" + invalid_char.group(0) + "' in parameter key: " + k)
 
@@ -414,7 +413,7 @@ class EFTemplateResolver(object):
     while go_again:
       go_again = False  # if at least one symbol isn't resolved in a pass, stop
       # Gather all resolvable symbols in the template
-      template_symbols = set(re.findall(SYMBOL_PATTERN, self.template))
+      template_symbols = set(symbol_pattern.findall(self.template))
       self.symbols.update(template_symbols)  # include this pass's symbols in full set
       # resolve and replace symbols
       for symbol in template_symbols:


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-13901](https://ellation.atlassian.net/browse/OPS-13901)

# Details
Updated the symbol matching used by EFTemplateResolver to allow for an optional leading dot. eg. {{foo}} and {{.foo}} are both allowable lookups, and will resolve "foo": "bar" in the parameters JSON. 

Since I was modifying this code anyway I also updated the regex searches to use a pre-compiled regex string for faster lookups.

# Testing
Tested using configs/test-instance/templates/config.json with the prod env and modified one of the two symbols to use a leading dot.

template:
```
{
    "secret": "{{.secret}}",
    "threads": "{{thread_count}}"
}
```

parameters:
```
"prod": {
      "secret": "{{aws:kms:decrypt,AQICAHgKKKY71tobDHsDpqGJpxUVx1IxoYgan68yJy9Qn2fHfQEp9aOMyaNg8LlOwWTr1q10AAAAijCBhwYJKoZIhvcNAQcGoHoweAIBADBzBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDOm8Fn7CbwEkS03zTwIBEIBG9dSJmOoPgmTANsDTMaRWM9pv4ChmmLBJM4awIW0LlLUIBvOXtjgxHhbjf0WiVq3ym2agnEGoskHMDf+jdYNFpZiu5G0s3Q==}}",
      "thread_count": "100"
    }
```

ef-resolve-config:
```
{
    "secret": "flectere si nequeo superos acheronta movebo",
    "threads": "100"
}
```

ef-cf also successfully renders cloudformation templates:
```
/Users/dlutsch/.local/share/virtualenvs/ef-open-43I3Cg99/bin/python /Users/dlutsch/workspace/ef-open/efopen/ef_cf.py cloudformation/services/templates/cst.json proto0 --lint
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
Warning: Permanently added 'github.com,192.30.255.113' (RSA) to the list of known hosts.
Template passed validation
=== CLOUDFORMATION LINTING ===
W2001 Parameter MonitoringIntervalParam not used.
.lint/template.json:29:5

W2001 Parameter MonitoringRoleArnParam not used.
.lint/template.json:33:5

W8001 Condition IsMultiZone not used
.lint/template.json:39:5

W8001 Condition EnvIsNotProd not used
.lint/template.json:45:5

W8001 Condition EnvIsProd not used
.lint/template.json:46:5

 
Template passed CFN linting

Process finished with exit code 0
```

