### PR TITLE
normalize encrypted string behavior in ef_instanceinit

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -691,7 +691,7 @@ class EFAwsResolver(object):
       The decrypted lookup value
     """
     decrypted_lookup = ef_utils.kms_decrypt(EFAwsResolver.__CLIENTS["kms"], lookup)
-    return decrypted_lookup
+    return decrypted_lookup.decode('string_escape')
 
   def kms_key_arn(self, lookup):
     """


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
Currently, KMS-encrypted strings are evaluated one time less than non-encrypted strings by ef-instanceinit. This will normalize the behavior between the two. 