### PR TITLE
remove pointless repo validation

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -101,7 +101,7 @@ def handle_args_and_set_context(args):
     a populated EFCFContext object (extends EFContext)
   Raises:
     IOError: if service registry file can't be found or can't be opened
-    RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
+    RuntimeError: if branch isn't as spec'd in ef_config.EF_REPO_BRANCH
     CalledProcessError: if 'git rev-parse' command to find repo root could not be run
   """
   parser = argparse.ArgumentParser()

--- a/efopen/ef_conf_utils.py
+++ b/efopen/ef_conf_utils.py
@@ -53,18 +53,10 @@ def env_valid(env):
 
 def pull_repo():
   """
-  Pulls latest version of EF_REPO_BRANCH from EF_REPO (as set in ef_config.py) if client is in EF_REPO
-  and on the branch EF_REPO_BRANCH
+  Pulls latest version of EF_REPO_BRANCH
   Raises:
-    RuntimeError with message if not in the correct repo on the correct branch
+    RuntimeError with message if not on the correct branch
   """
-  try:
-    current_repo = subprocess.check_output(["git", "remote", "-v", "show"])
-  except subprocess.CalledProcessError as error:
-    raise RuntimeError("Exception checking current repo", error)
-  current_repo = re.findall(r"(.*?https://|.*?@)(.*?@)?(.*?)(\.git.*)", current_repo)[0][2].replace(":", "/")
-  if current_repo != EFConfig.EF_REPO:
-    raise RuntimeError("Must be in " + EFConfig.EF_REPO + " repo. Current repo is: " + current_repo)
   try:
     current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).rstrip()
   except subprocess.CalledProcessError as error:

--- a/efopen/ef_config.py
+++ b/efopen/ef_config.py
@@ -34,7 +34,6 @@ class EFConfig(object):
     CUSTOM_DATA = _ef_site_config["CUSTOM_DATA"]
   DEFAULT_REGION = _ef_site_config["DEFAULT_REGION"]
   EF_CF_POLL_PERIOD = _ef_site_config["EF_CF_POLL_PERIOD"]
-  EF_REPO = _ef_site_config["EF_REPO"]
   EF_REPO_BRANCH = _ef_site_config["EF_REPO_BRANCH"]
   ENV_ACCOUNT_MAP = _ef_site_config["ENV_ACCOUNT_MAP"]
   EPHEMERAL_ENVS = _ef_site_config["EPHEMERAL_ENVS"]

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -112,7 +112,7 @@ def handle_args_and_set_context(args):
     a populated EFContext object
   Raises:
     IOError: if service registry file can't be found or can't be opened
-    RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
+    RuntimeError: if branch isn't as spec'd in ef_config.EF_REPO_BRANCH
     CalledProcessError: if 'git rev-parse' command to find repo root could not be run
   """
   parser = argparse.ArgumentParser()

--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -152,7 +152,7 @@ def handle_args_and_set_context(args):
   Returns:
       a populated EFPWContext object
   Raises:
-      RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
+      RuntimeError: if branch isn't as spec'd in ef_config.EF_REPO_BRANCH
       ValueError: if a parameter is invalid
   """
   parser = argparse.ArgumentParser()

--- a/efopen/ef_service_registry.py
+++ b/efopen/ef_service_registry.py
@@ -37,7 +37,7 @@ class EFServiceRegistry(object):
       service_registry_file: the file containing the service registry
     Raises:
       IOError: if file can't be found or can't be opened
-      RuntimeError: if repo or branch isn't as spec'd in ef_config.EF_REPO and ef_config.EF_REPO_BRANCH
+      RuntimeError: if branch isn't as spec'd in ef_config.EF_REPO_BRANCH
       CalledProcessError: if 'git rev-parse' command to find repo root could not be run
     """
     # If a file wasn't provided, try to fetch the default

--- a/getting-started/ef_site_config.yml
+++ b/getting-started/ef_site_config.yml
@@ -18,11 +18,7 @@
 #   Example: DEFAULT_REGION: "us-east-1"
 DEFAULT_REGION: ""
 
-# Repo where tools and all EF data are
-#   Example: EF_REPO: "github.com/account/repo"
-EF_REPO: ""
-
-# Branch in EF_REPO to deploy CloudFormation templates from; probably "master"
+# Branch in of repo to deploy CloudFormation templates from; probably "master"
 #   Example: EF_REPO_BRANCH: "master"
 EF_REPO_BRANCH: "master"
 

--- a/tests/unit_tests/test_ef_conf_utils.py
+++ b/tests/unit_tests/test_ef_conf_utils.py
@@ -149,96 +149,6 @@ class TestEFConfUtils(unittest.TestCase):
       ef_conf_utils.env_valid(None)
 
   @patch('subprocess.check_output')
-  def test_pull_repo_ssh_credentials(self, mock_check_output):
-    """
-    Tests pull_repo by mocking the subprocess.check_output to return git ssh credentials.
-
-    Args:
-      mock_check_output: MagicMock, returns valid git responses in order of being called, with the
-      repo coming from the ef_site_config.py
-
-    Returns:
-      None
-
-    Raises:
-      AssertionError if any of the assert checks fail
-    """
-
-    try:
-      mock_check_output.side_effect = [
-        "user@" + EFConfig.EF_REPO.replace("/", ":", 1) + ".git",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\tuser@" + EFConfig.EF_REPO.replace("/", ":", 1) + ".git",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\tuser@" + EFConfig.EF_REPO.replace("/", ":", 1) + ".git (fetch)",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\tuser@" + EFConfig.EF_REPO.replace("/", ":", 1) + ".git (push)",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-    except RuntimeError as exception:
-      self.fail("Exception occurred during test_pull_repo_ssh_credentials: " + exception.message)
-
-  @patch('subprocess.check_output')
-  def test_pull_repo_https_credentials(self, mock_check_output):
-    """
-    Tests the pull_repo by mocking the subprocess.check_output to return git http credentials.
-
-    Args:
-      mock_check_output: MagicMock, returns valid git responses in order of being called, with the
-      repo coming from the ef_site_config.py
-
-    Returns:
-      None
-
-    Raises:
-      AssertionError if any of the assert checks fail
-    """
-
-    try:
-      mock_check_output.side_effect = [
-        "https://" + EFConfig.EF_REPO + ".git",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\thttps://" + EFConfig.EF_REPO + ".git",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "https://8c3c99990fd0fa55454634dad85f8a48beaa1916@" + EFConfig.EF_REPO + ".git",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\thttps://8c3c99990fd0fa55454634dad85f8a48beaa1916@" + EFConfig.EF_REPO + ".git",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\thttps://8c3c99990fd0fa55454634dad85f8a48beaa1916@" + EFConfig.EF_REPO + ".git (fetch)",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-      mock_check_output.side_effect = [
-        "origin\thttps://8c3c99990fd0fa55454634dad85f8a48beaa1916@" + EFConfig.EF_REPO + ".git (push)",
-        EFConfig.EF_REPO_BRANCH
-      ]
-      ef_conf_utils.pull_repo()
-    except RuntimeError as exception:
-      self.fail("Exception occurred during test_pull_repo_ssh_credentials: " + exception.message)
-
-  @patch('subprocess.check_output')
   def test_pull_repo_incorrect_repo(self, mock_check_output):
     """
     Tests pull_repo to see if it throws an exception when the supplied repo doesn't match the one in
@@ -260,30 +170,6 @@ class TestEFConfUtils(unittest.TestCase):
     with self.assertRaises(RuntimeError) as exception:
       ef_conf_utils.pull_repo()
     self.assertIn("Must be in", exception.exception.message)
-
-  @patch('subprocess.check_output')
-  def test_pull_repo_incorrect_branch(self, mock_check_output):
-    """
-    Tests pull_repo to see if it throws an error when the mocked check_output states it's on a branch
-    other than the one specified in ef_site_config.py
-
-    Args:
-      mock_check_output: MagicMock, returns some valid git responses, with the
-      repo coming from the ef_site_config.py, and then a non matching branch name
-
-    Returns:
-      None
-
-    Raises:
-      AssertionError if any of the assert checks fail
-    """
-    mock_check_output.side_effect = [
-      "user@" + EFConfig.EF_REPO.replace("/", ":", 1) + ".git",
-      "wrong_branch"
-    ]
-    with self.assertRaises(RuntimeError) as exception:
-      ef_conf_utils.pull_repo()
-    self.assertIn("Must be on branch:", exception.exception.message)
 
   def test_get_account_alias(self):
     """


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
I can close this PR if anyone can give me a valid reason why we care about checking the repo. As it is the current regex is causing ef-cf to fail if the repo was not cloned with the ".git" suffix. But really, what are we trying to protect against here?

# Testing
```
/Users/dlutsch/.local/share/virtualenvs/ef-open-43I3Cg99/bin/python /Users/dlutsch/workspace/ef-open/efopen/ef_cf.py cloudformation/services/templates/data-dbclient.json prod --lint
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
Template passed validation
=== CLOUDFORMATION LINTING ===
W3005 Obsolete DependsOn on resource (ExternalElasticLoadBalancer), dependency already enforced by a "Fn:GetAtt" at Resources/PublicDns/Properties/RecordSets/0/AliasTarget/HostedZoneId/Fn::GetAtt/['ExternalElasticLoadBalancer', 'CanonicalHostedZoneNameID']
.lint/template.json:86:22

W3005 Obsolete DependsOn on resource (ExternalElasticLoadBalancer), dependency already enforced by a "Fn:GetAtt" at Resources/PublicDns/Properties/RecordSets/0/AliasTarget/DNSName/Fn::GetAtt/['ExternalElasticLoadBalancer', 'CanonicalHostedZoneName']
.lint/template.json:86:22

W3005 Obsolete DependsOn on resource (Ec2Instance), dependency already enforced by a "Fn:GetAtt" at Resources/PrivateDns/Properties/ResourceRecords/0/Fn::GetAtt/['Ec2Instance', 'PrivateIp']
.lint/template.json:105:7

 
Template passed CFN linting

Process finished with exit code 0
```