### PR TITLE
Add vpn-gateway-id lookup in ef_aws_resolver

### DIFF
--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -241,7 +241,7 @@ which is looked in 'proto3' as:<br>
 returns:<br>
 ```vpc-21ac3315```<br>
 
-#### {{aws:ec2:vpc/vpc-id,\<vpc_friendly_name>}}
+#### {{aws:ec2:vpc/vpc-id,\<vgw_friendly_name>}}
 Returns: Virtual Private Gateway's ID<br>
 Needs: VPN Gateway's friendly name, which is always "vgw-\<az>"<br>
 Example:<br>

--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -241,7 +241,7 @@ which is looked in 'proto3' as:<br>
 returns:<br>
 ```vpc-21ac3315```<br>
 
-#### {{aws:ec2:vpc/vpc-id,\<vgw_friendly_name>}}
+#### {{aws:ec2:vpc/vpn-gateway-id,\<vgw_friendly_name>}}
 Returns: Virtual Private Gateway's ID<br>
 Needs: VPN Gateway's friendly name, which is always "vgw-\<az>"<br>
 Example:<br>

--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -241,6 +241,16 @@ which is looked in 'proto3' as:<br>
 returns:<br>
 ```vpc-21ac3315```<br>
 
+#### {{aws:ec2:vpc/vpc-id,\<vpc_friendly_name>}}
+Returns: Virtual Private Gateway's ID<br>
+Needs: VPN Gateway's friendly name, which is always "vgw-\<az>"<br>
+Example:<br>
+```{{aws:ec2:vpc/vpn-gateway-id,vpnGateway-{{ENV}}}}```<br>
+which is looked in 'proto3' as:<br>
+```{{aws:ec2:vpc/vpn-gateway-id,vpnGateway-proto3}}```<br>
+returns:<br>
+```vgw-1f20f901```<br>
+
 #### {{aws:elbv2:load-balancer/dns-name,\<load_balancer_name>}}
 TODO:
 

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -335,12 +335,12 @@ class EFAwsResolver(object):
     Returns:
       The ID of the first VPN Gateway found with a label matching 'lookup' or default/None if no match found
     """
-    vpcs = EFAwsResolver.__CLIENTS["ec2"].describe_vpcs(Filters=[{
-      'Name': 'tag:Name',
-      'Values': [lookup]
+    vpn_gateways = EFAwsResolver.__CLIENTS["ec2"].describe_vpn_gateways(Filters=[{
+      "Name": "tag:Name",
+      "Values": [lookup]
     }])
-    if len(vpcs.get("Vpcs")) > 0:
-      return vpcs["Vpcs"][0]["VpnGatewayId"]
+    if len(vpn_gateways) > 0:
+      return vpn_gateways["VpnGateways"][0]["VpnGatewayId"]
     else:
       return default
     

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -327,6 +327,23 @@ class EFAwsResolver(object):
     else:
       return default
 
+  def ec2_vpc_vpn_gateway_id(self, lookup, default=None):
+    """
+    Args:
+      lookup: the friendly name of the VPC whose VPN Gateway ID we want
+      default: the optional value to return if lookup failed; returns None if not set
+    Returns:
+      The ID of the first VPN Gateway found with a label matching 'lookup' or default/None if no match found
+    """
+    vpcs = EFAwsResolver.__CLIENTS["ec2"].describe_vpcs(Filters=[{
+      'Name': 'tag:Name',
+      'Values': [lookup]
+    }])
+    if len(vpcs.get("Vpcs")) > 0:
+      return vpcs["Vpcs"][0]["VpnGatewayId"]
+    else:
+      return default
+    
   def elbv2_load_balancer_hosted_zone(self, lookup, default=None):
     """
     Args:
@@ -750,6 +767,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_subnets(*kv[1:])
     elif kv[0] == "ec2:vpc/vpc-id":
       return self.ec2_vpc_vpc_id(*kv[1:])
+    elif kv[0] == "ec2:vpc/vpn-gateway-id":
+      return self.ec2_vpc_vpn_gateway_id(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/dns-name":
       return self.elbv2_load_balancer_dns_name(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/hosted-zone":

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -330,10 +330,10 @@ class EFAwsResolver(object):
   def ec2_vpc_vpn_gateway_id(self, lookup, default=None):
     """
     Args:
-      lookup: the friendly name of the VPC whose VPN Gateway ID we want
+      lookup: the friendly name of the VPN Gateway ID to look up
       default: the optional value to return if lookup failed; returns None if not set
     Returns:
-      The ID of the first VPN Gateway found with a label matching 'lookup' or default/None if no match found
+      The ID of the VPN Gateway found with a label matching 'lookup' or default/None if no match found
     """
     vpn_gateways = EFAwsResolver.__CLIENTS["ec2"].describe_vpn_gateways(Filters=[{
       "Name": "tag:Name",

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -867,6 +867,23 @@ class TestEFAwsResolver(unittest.TestCase):
     result = ef_aws_resolver.lookup("ec2:vpc/vpc-id,target_vpc_name")
     self.assertIsNone(result)
 
+  def test_ec2_vpc_vpn_gateway_id(self):
+    """
+    Tests VPN Gateway ID lookup
+    """
+    vpn_gateway_id = "vgw-6cc41f72"
+    vpn_gateway_response = {
+      "VpnGateways": [
+        {
+          "VpnGatewayId": vpn_gateway_id
+        }
+      ]
+    }
+    self._clients["ec2"].describe_vpn_gateways.return_value = vpn_gateway_response
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    result = ef_aws_resolver.lookup("ec2:vpc/vpn-gateway-id,vpnGateway-name")
+    self.assertEquals(vpn_gateway_id, result)
+    
   def test_waf_rule_id(self):
     """
     Tests waf_rule_id to see if it returns the rule id that matches the rule name


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Add the ability to look up VPN Gateway ID.
[OPS-14174](https://ellation.atlassian.net/browse/OPS-14174)

## Changelog
- add VPN Gateway ID lookup

## Linked PRs
https://github.com/crunchyroll/ellation_formation/pull/5703

## Testing
`python ../ef-open/efopen/ef_cf.py vpn-md.json proto0 --devel --verbose`
```
...
"vpnToVpcAttachment": {
      "Type": "AWS::EC2::VPCGatewayAttachment",
      "Properties": {
        "VpcId": "vpc-3939795d",
        "VpnGatewayId": "vgw-e021f8fe"
      }
    }