### PR TITLE
Fix newrelic executor error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,6 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 venv/
-.vscode
+
+# VS Code
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 venv/
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/alexandru.bantiuc/workspace/ef-open/venv/bin/python2.7"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/alexandru.bantiuc/workspace/ef-open/venv/bin/python2.7"
-}

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -553,8 +553,9 @@ def create_newrelic_alerts():
    Create Newrelic Alerts for each entry in the service registry application_services
    Note: Import is inside this function rather than top of the file so that we do not import when running unit tests.
          (would otherwise require an ef_site_config.yml in the directory where tests are being run)
-   """
-pass
+  """
+  pass
+ 
 def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER
 

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -554,6 +554,7 @@ def create_newrelic_alerts():
    Note: Import is inside this function rather than top of the file so that we do not import when running unit tests.
          (would otherwise require an ef_site_config.yml in the directory where tests are being run)
    """
+pass
 def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER
 

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -554,9 +554,6 @@ def create_newrelic_alerts():
    Note: Import is inside this function rather than top of the file so that we do not import when running unit tests.
          (would otherwise require an ef_site_config.yml in the directory where tests are being run)
    """
-  from newrelic.executor import NewRelicAlerts
-  NewRelicAlerts(CONTEXT, CLIENTS).run()
-
 def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER
 


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Fix newrelic executor error
[OPS-14184](https://ellation.atlassian.net/browse/OPS-14184)
## Changelog
- remove newrelic.executor module


## Testing
Before:
```
$ ef-generate staging --commit --dev
...
  File "/usr/local/bin/ef-generate", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/efopen/ef_generate.py", line 642, in main
    create_newrelic_alerts()
  File "/usr/local/lib/python2.7/site-packages/efopen/ef_generate.py", line 557, in create_newrelic_alerts
    from newrelic.executor import NewRelicAlerts
ImportError: No module named newrelic.executor
```
After:
```
$ ef-generate staging --commit --dev
...
Exit: success
```