### PR TITLE
readd newrelic alerts, fix import statement

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -554,7 +554,8 @@ def create_newrelic_alerts():
    Note: Import is inside this function rather than top of the file so that we do not import when running unit tests.
          (would otherwise require an ef_site_config.yml in the directory where tests are being run)
   """
-  pass
+  from efopen.newrelic.executor import NewRelicAlerts
+  NewRelicAlerts(CONTEXT, CLIENTS).run()
  
 def main():
   global CONTEXT, CLIENTS, AWS_RESOLVER


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-14226](https://ellation.atlassian.net/browse/OPS-14226)

# Details
Fixes Newrelic alert creation. Previously this import statement was `from newrelic.executor import NewRelicAlerts` which worked locally because I had the repo in my python path, but not for anyone else. This should fix the error by including the parent module in the import path. 