### PR TITLE
OPS-14161 Allow subservices to decrypt main service secrets

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -464,6 +464,10 @@ def conditionally_create_kms_key(role_name, service_type):
       ]
     }
   else:
+    role_principal = [ "arn:aws:iam::{}:role/{}".format(account_id, role_name) ]
+    if '.' not in role_name:
+      subservice_principals = "arn:aws:iam::{}:role/{}.*".format(account_id, role_name)
+      role_principal.append(subservice_principals)
     kms_key_policy = {
       "Version": "2012-10-17",
       "Statement": [
@@ -479,9 +483,14 @@ def conditionally_create_kms_key(role_name, service_type):
         {
           "Sid": "Allow Service Role Decrypt Privileges",
           "Effect": "Allow",
-          "Principal": { "AWS":"arn:aws:iam::{}:role/{}".format(account_id, role_name) },
+          "Principal": "*",
           "Action": "kms:Decrypt",
-          "Resource": "*"
+          "Resource": "*",
+          "Condition": {
+                "ForAnyValue:StringLike": {
+                    "aws:PrincipalArn": role_principal
+                }
+            }
         },
         {
           "Sid": "Allow use of the key for default autoscaling group service role",


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-14161](https://ellation.atlassian.net/browse/OPS-14161)

# Details
In order to avoid the multiple encryption steps for a service with subservices, we will allow subservices to decrypt secrets encrypted with the main service's key.
