### PR TITLE
Use pip to install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
     - "2.7"
 
 install:
-    - python setup.py install
-    - python setup.py test
+    - pip install -e .
 script:
     python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
     - "2.7"
 
 install:
-    - pip install -e .
+    - pip install .
 script:
     python -m unittest discover


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
Due to a strange issue with Python's setup-tools, running `python setup.py install` does not resolve the correct version of `zipp` for Python2, failing the build. This might be related to Python 2 getting deprecated.

`pip` seems to work fine, so switching to it for the installation.