### PR TITLE
Add ability to get vpc endpoint ids in AWS resolver

### DIFF
--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -259,6 +259,16 @@ which is looked in 'proto3' as:<br>
 returns:<br>
 ```vpc-21ac3315```<br>
 
+#### {{aws:ec2:vpc-endpoint/vpc-endpoint-id,\<vpc_endpoint_friendly_name>}}
+Returns: VPC Endpoint ID
+Needs: VPC Endpoint's friendly name, which is generally "vpce-\<env>"<br>
+Example:<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpce-{{ENV}}}}```<br>
+which is looked in 'proto3' as:<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpce-proto3}}```<br>
+returns:<br>
+```vpce-123```
+
 #### {{aws:ec2:vpc/vpn-gateway-id,\<vgw_friendly_name>}}
 Returns: Virtual Private Gateway's ID<br>
 Needs: VPN Gateway's friendly name, which is always "vgw-\<az>"<br>

--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -260,7 +260,7 @@ returns:<br>
 ```vpc-21ac3315```<br>
 
 #### {{aws:ec2:vpc-endpoint/vpc-endpoint-id,\<vpc_endpoint_friendly_name>}}
-Returns: VPC Endpoint ID
+Returns: VPC Endpoint ID<br>
 Needs: VPC Endpoint's friendly name, which is generally "vpce-\<env>"<br>
 Example:<br>
 ```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpce-{{ENV}}}}```<br>

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -339,7 +339,7 @@ class EFAwsResolver(object):
       "Name": "tag:Name",
       "Values": [lookup]
     }])
-    if len(vpc_endpoints) > 0:
+    if len(vpc_endpoints.get("VpcEndpoints")) > 0:
       return vpc_endpoints["VpcEndpoints"][0]["VpcEndpointId"]
     else:
       return default

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -327,6 +327,23 @@ class EFAwsResolver(object):
     else:
       return default
 
+  def ec2_vpc_endpoint_id(self, lookup, default=None):
+    """
+    Args:
+      lookup: the name of the VPC endpoint to look up (in tags)
+      default: the optional value to return if lookup failed; returns None if not set
+    Returns:
+      The ID of the VPC Endpoint found with a label matching 'lookup' or default/None if no match found
+    """
+    vpc_endpoints = EFAwsResolver.__CLIENTS["ec2"].describe_vpc_endpoints(Filters=[{
+      "Name": "tag:Name",
+      "Values": [lookup]
+    }])
+    if len(vpc_endpoints) > 0:
+      return vpc_endpoints["VpcEndpoints"][0]["VpcEndpointId"]
+    else:
+      return default
+
   def ec2_vpc_vpn_gateway_id(self, lookup, default=None):
     """
     Args:
@@ -819,6 +836,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_subnets(*kv[1:])
     elif kv[0] == "ec2:vpc/vpc-id":
       return self.ec2_vpc_vpc_id(*kv[1:])
+    elif kv[0] == "ec2:vpc-endpoint/vpc-endpoint-id":
+      return self.ec2_vpc_endpoint_id(*kv[1:])
     elif kv[0] == "ec2:vpc/vpn-gateway-id":
       return self.ec2_vpc_vpn_gateway_id(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/dns-name":

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -912,6 +912,50 @@ class TestEFAwsResolver(unittest.TestCase):
     result = ef_aws_resolver.lookup("ec2:vpc/vpc-id,target_vpc_name")
     self.assertIsNone(result)
 
+  def test_ec2_vpc_endpoint_id(self):
+    """
+    Tests that this function returns the vpc endpoint id when it finds a 
+    resource with the right tag.
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    expected_vpce_id = "vpce-123"
+    describe_vpce_response = {
+      "VpcEndpoints": [
+        {
+          "VpcEndpointId": "vpce-123",
+          "VpcEndpointType": "Interface",
+          "VpcId": "vpc-01"
+        }
+      ]
+    }
+    self._clients["ec2"].describe_vpc_endpoints.return_value = describe_vpce_response
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    result = ef_aws_resolver.lookup("ec2:vpc-endpoint/vpc-endpoint-id,target_vpc_endpoint_name")
+    self.assertEquals(expected_vpce_id, result)
+
+  def test_ec2_vpc_endpoint_id_none(self):
+    """
+    Tests that this function returns None if it can't find a match
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    describe_vpce_response = {
+      "VpcEndpoints": []
+    }
+    self._clients["ec2"].describe_vpc_endpoints.return_value = describe_vpce_response
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    result = ef_aws_resolver.lookup("ec2:vpc-endpoint/vpc-endpoint-id,target_vpc_endpoint_name")
+    self.assertIsNone(result)
+
   def test_ec2_vpc_vpn_gateway_id(self):
     """
     Tests VPN Gateway ID lookup


### PR DESCRIPTION
# Ready State and Ticket
> Valid states are:
> Ready - This PR is ready to be reviewed.
> Not Ready - Please provide an explanation below.

**Ready**
[ESS-2498](https://ellation.atlassian.net/browse/ESS-2498)

# Details
> A description of the motivation and implementation of this PR.
> Include any relevant details like:
> - Test results
> - Unusual deployment requirements
> - Current deployed state, if any
> - General issues for discussion during the review

In order to limit traffic to a private API Gateway, I would like to be able to specify which VPC endpoint is allowed to talk to it. Unfortunately, this requires specifying the VPC endpoint ID in the API Gateway resource in CloudFormation, and `ef-open` does not have a method for doing so. This PR adds that method.