### PR TITLE
Add ability to get VPC endpoint ID by VPC name and Service name

### DIFF
--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -269,13 +269,13 @@ which is looked in 'proto3' as:<br>
 returns:<br>
 ```vpce-123```
 
-#### {{aws:ec2:vpc-endpoint/vpc-endpoint-id-by-vpc-service,\<vpc_name/service_name>}}
+#### {{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,\<vpc_name/service_name>}}
 Returns: VPC Endpoint ID<br>
 Needs: VPC friendly name and service name<br>
 Example:<br>
-```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpc-{{ENV}}/execute-api}}```<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,vpc-{{ENV}}/execute-api}}```<br>
 which is looked in 'proto3' as:<br>
-```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpc-proto3/execute-api}}```<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,vpc-proto3/execute-api}}```<br>
 returns:<br>
 ```vpce-123```
 

--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -269,6 +269,16 @@ which is looked in 'proto3' as:<br>
 returns:<br>
 ```vpce-123```
 
+#### {{aws:ec2:vpc-endpoint/vpc-endpoint-id-by-vpc-service,\<vpc_name/service_name>}}
+Returns: VPC Endpoint ID<br>
+Needs: VPC friendly name and service name<br>
+Example:<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpc-{{ENV}}/execute-api}}```<br>
+which is looked in 'proto3' as:<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id,vpc-proto3/execute-api}}```<br>
+returns:<br>
+```vpce-123```
+
 #### {{aws:ec2:vpc/vpn-gateway-id,\<vgw_friendly_name>}}
 Returns: Virtual Private Gateway's ID<br>
 Needs: VPN Gateway's friendly name, which is always "vgw-\<az>"<br>

--- a/doc/symbol-reference.md
+++ b/doc/symbol-reference.md
@@ -273,9 +273,9 @@ returns:<br>
 Returns: VPC Endpoint ID<br>
 Needs: VPC friendly name and service name<br>
 Example:<br>
-```{{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,vpc-{{ENV}}/execute-api}}```<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,vpc-{{ENV}}/com.amazonaws.{{REGION}}.execute-api}}```<br>
 which is looked in 'proto3' as:<br>
-```{{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,vpc-proto3/execute-api}}```<br>
+```{{aws:ec2:vpc-endpoint/vpc-endpoint-id/by-vpc-service,vpc-proto3/com.amazonaws.us-east-1.execute-api}}```<br>
 returns:<br>
 ```vpce-123```
 


### PR DESCRIPTION
# Ready State and Ticket
> Valid states are:
> Ready - This PR is ready to be reviewed.
> Not Ready - Please provide an explanation below.

**Ready**
[ESS-2498](https://ellation.atlassian.net/browse/ESS-2498)

# Details
> A description of the motivation and implementation of this PR.
> Include any relevant details like:
> - Test results
> - Unusual deployment requirements
> - Current deployed state, if any
> - General issues for discussion during the review

As it turns out, while AWS did add support for tags for VPC endpoints, you can only add them through the EC2 API / console. CloudFormation currently does not support it, though it is on their roadmap (https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/projects/1).

As such, we needed a new way to find a specific VPC endpoint. We reasoned that we are unlikely to have more than 1 defined VPC endpoint resource for a given service per VPC. This PR adds that functionality. If more than 1 is found, we return the ID of the *oldest* match.

Since we would prefer to find the VPC endpoint by tag later on, I kept that functionality.