### PR TITLE
Fix error handling for missing KMS aliases

### DIFF
--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -267,7 +267,7 @@ def kms_key_alias(kms_client, key_arn):
     key_aliases = [key_data["AliasName"] for key_data in response["Aliases"]]
     clean_aliases = [alias.split('/', 1)[1] for alias in key_aliases]
   except ClientError as error:
-    raise RuntimeError("Failed to obtain key arn for alias {}, error: {}".format(alias, error.response["Error"]["Message"]))
+    raise RuntimeError("Failed to obtain key alias for arn {}, error: {}".format(key_arn, error.response["Error"]["Message"]))
 
   return clean_aliases
 

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -734,7 +734,7 @@ class TestEFUtilsKMS(unittest.TestCase):
     with self.assertRaises(SystemExit):
       ef_utils.kms_decrypt(self.mock_kms, self.secret)
 
-  def test_get_kms_key_alisa(self):
+  def test_get_kms_key_alias(self):
     """Test that kms_key_alias can get a key_alias by arn"""
     service_key_alias = 'service-name'
     key_arn = 'random-ARN'
@@ -745,7 +745,7 @@ class TestEFUtilsKMS(unittest.TestCase):
     self.assertIn(service_key_alias, aliases)
     self.mock_kms.list_aliases.assert_called_once_with(KeyId=key_arn)
 
-  def test_get_kms_key_alisa(self):
+  def test_get_kms_key_alias_client_error(self):
     """Test that kms_key_alias can get a key_alias by arn"""
     service_key_alias = 'service-name'
     key_arn = 'random-ARN'

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -733,3 +733,22 @@ class TestEFUtilsKMS(unittest.TestCase):
     self.mock_kms.decrypt.side_effect = self.client_error
     with self.assertRaises(SystemExit):
       ef_utils.kms_decrypt(self.mock_kms, self.secret)
+
+  def test_get_kms_key_alisa(self):
+    """Test that kms_key_alias can get a key_alias by arn"""
+    service_key_alias = 'service-name'
+    key_arn = 'random-ARN'
+    self.mock_kms.list_aliases.return_value = {
+      "Aliases": [ {"AliasName": "alias/{}".format(service_key_alias)} ]
+    }
+    aliases = ef_utils.kms_key_alias(self.mock_kms, key_arn)
+    self.assertIn(service_key_alias, aliases)
+    self.mock_kms.list_aliases.assert_called_once_with(KeyId=key_arn)
+
+  def test_get_kms_key_alisa(self):
+    """Test that kms_key_alias can get a key_alias by arn"""
+    service_key_alias = 'service-name'
+    key_arn = 'random-ARN'
+    self.mock_kms.list_aliases.side_effect = self.client_error
+    with self.assertRaises(RuntimeError):
+      aliases = ef_utils.kms_key_alias(self.mock_kms, key_arn)


### PR DESCRIPTION
# Ready State and Ticket
**Ready**

# Details
During the setup for checking the encryption key, I copy pasted from the `kms_key_arn` function and didn't run through all of the test cases.