### PR TITLE
OPS-14634 Create CloudFront alerts in NewRelic

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -583,11 +583,11 @@ def main():
   try:
     # If running in EC2, always use instance credentials. One day we'll have "lambda" in there too, so use "in" w/ list
     if CONTEXT.whereami == "ec2":
-      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, None, "ec2", "iam", "kms")
+      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, None, "cloudfront", "ec2", "iam", "kms")
       CONTEXT.account_id = str(json.loads(http_get_metadata('iam/info'))["InstanceProfileArn"].split(":")[4])
     else:
       # Otherwise, we use local user creds based on the account alias
-      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, CONTEXT.account_alias, "ec2", "iam", "kms", "sts")
+      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, CONTEXT.account_alias, "cloudfront", "ec2", "iam", "kms", "sts")
       CONTEXT.account_id = get_account_id(CLIENTS["sts"])
   except RuntimeError:
     fail("Exception creating AWS clients in region {} with profile {}".format(

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -153,7 +153,7 @@ class NewRelicAlerts(object):
                 policy.config_conditions[condition_name][override_key] = override_value
         logger.debug("Policy {} alert condition values:\n{}".format(policy.name, policy.config_conditions))
 
-        policy = self.remove_redundant_conditions(policy)
+        policy = self.remove_redundant_policy_conditions(policy)
         self.create_policy_conditions(policy)
 
   def run(self):

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -39,63 +39,130 @@ class NewRelicAlerts(object):
       condition_obj = convert_string(condition_obj)
     return condition_obj
 
+  def create_policy(self, newrelic, service_name):
+    policy = AlertPolicy(env=self.context.env, service=service_name)
+
+    # Create service alert policy if it doesn't already exist
+    if not newrelic.alert_policy_exists(policy.name):
+      newrelic.create_alert_policy(policy.name)
+      logger.info("create alert policy {}".format(policy.name))
+    policy.id = next(alert['id'] for alert in newrelic.all_alerts if alert['name'] == policy.name)
+    policy.notification_channels = self.all_notification_channels[self.context.env]
+    policy.conditions = newrelic.get_policy_alert_conditions(policy.id)
+    policy.config_conditions = deepcopy(self.conditions)
+    return policy
+
+  def remove_redundant_policy_conditions(self, newrelic, policy):
+    # Remove conditions with values that differ from config
+    for condition in policy.conditions:
+      if condition['name'] in policy.config_conditions:
+        config_condition = policy.config_conditions[condition['name']]
+        for k, v in config_condition.items():
+          if condition[k] != v:
+            newrelic.delete_policy_alert_condition(condition['id'])
+            policy.conditions = newrelic.get_policy_alert_conditions(policy.id)
+            logger.info("delete condition {} from policy {}. ".format(condition['name'], policy.name) + \
+                        "current value differs from config")
+            break
+
+    return policy
+
+  def create_policy_conditions(self, newrelic, policy):
+    # Create alert conditions for policies
+    for key, value in policy.config_conditions.items():
+      if not any(d['name'] == key for d in policy.conditions):
+        newrelic.create_alert_cond(policy.config_conditions[key])
+        logger.info("create condition {} for policy {}".format(key, policy.name))
+
+  def update_cloudfront_policy(self, token):
+    logger.info("update cloudfront alert policy")
+    newrelic = NewRelic(self.admin_token)
+    cloudfront = self.clients['cloudfront']
+    distribution_list = cloudfront.list_distributions()['DistributionList']
+    map_function = lambda x: (x['Id'], ', '.join(x['Aliases']['Items']))
+    queue = map(map_function, distribution_list['Items'])
+
+    while distribution_list['IsTruncated']:
+      distribution_list = cloudfront.list_distributions(Marker=distribution_list['NextMarker'])['DistributionList']
+      queue.extend(map(map_function, distribution_list['Items']))
+
+    # Create policy conditions
+    meta = lambda error_rate, value, distribution_id, name, policy_id: {
+      'select_value': 'provider.{}.Average'.format(error_rate),
+      'comparison': 'above',
+      'critical_threshold': {
+        'duration_minutes': 5,
+        'time_function': 'all',
+        'value': value
+      },
+      'enabled': True,
+      'event_type': 'LoadBalancerSample',
+      'filter': {
+        'and': [{
+          'is': {
+            'provider.distributionId': distribution_id
+          }
+        }]
+      },
+      'name': name,
+      'integration_provider': 'CloudFrontDistribution',
+      'policy_id': policy_id,
+      'type': 'infra_metric',
+    }
+
+    policy = self.create_policy(newrelic, 'cloudfront')
+    conditions = {}
+    for id, alias in queue:
+      conditions['cloudfront-{}-{}'.format(id, '4xxErrorRate')] = meta(
+        '4xxErrorRate', 10, id, '4xx Average {}'.format(alias), policy.id)
+      conditions['cloudfront-{}-{}'.format(id, '5xxErrorRate')] = meta(
+        '5xxErrorRate', 5, id, '5xx Average {}'.format(alias), policy.id)
+
+    policy.config_conditions = deepcopy(conditions)
+
+    policy = self.remove_redundant_policy_conditions(newrelic, policy)
+    self.create_policy_conditions(newrelic, policy)
+
+  def update_application_services_policies(self, token):
+    newrelic = NewRelic(self.admin_token)
+    for service in self.context.service_registry.iter_services(service_group="application_services"):
+      service_name = service[0]
+      service_environments = service[1]['environments']
+      service_alert_overrides = service[1]['alerts'] if "alerts" in service[1] else {}
+      if self.context.env in service_environments:
+
+        policy = self.create_policy(newrelic, service_name)
+
+        # Add alert policy to notification channels if missing
+        for channel in newrelic.all_channels:
+          if channel['name'] in policy.notification_channels and policy.id not in channel['links']['policy_ids']:
+            newrelic.add_policy_channels(policy.id, [channel['id']])
+            logger.info("add channel_ids {} to policy {}".format(policy.name, channel['id']))
+
+        # Replace symbols in config alert conditions
+        for key, value in policy.config_conditions.items():
+          policy.config_conditions[key] = self.replace_symbols(value, policy.symbols)
+
+        # Update policy.config_conditions with overrides from service_registry
+        for condition_name, override_obj in service_alert_overrides.items():
+          if condition_name in policy.config_conditions.keys():
+            for override_key, override_value in override_obj.items():
+              if isinstance(override_value, dict):
+                for inner_key, inner_val in override_value.items():
+                  policy.config_conditions[condition_name][override_key][inner_key] = inner_val
+              else:
+                policy.config_conditions[condition_name][override_key] = override_value
+        logger.debug("Policy {} alert condition values:\n{}".format(policy.name, policy.config_conditions))
+
+        policy = self.remove_redundant_conditions(newrelic, policy)
+        self.create_policy_conditions(newrelic, policy)
+
   def run(self):
     if self.context.env in self.all_notification_channels.keys():
       if self.config['token_kms_encrypted']:
         self.admin_token = kms_decrypt(self.clients['kms'], self.admin_token).plaintext
 
-      newrelic = NewRelic(self.admin_token)
-      for service in self.context.service_registry.iter_services(service_group="application_services"):
-        service_name = service[0]
-        service_environments = service[1]['environments']
-        service_alert_overrides = service[1]['alerts'] if "alerts" in service[1] else {}
-        if self.context.env in service_environments:
+      self.update_application_services_policies(self.admin_token)
 
-          policy = AlertPolicy(env=self.context.env, service=service_name)
-          # Create service alert policy if it doesn't already exist
-          if not newrelic.alert_policy_exists(policy.name):
-            newrelic.create_alert_policy(policy.name)
-            logger.info("create alert policy {}".format(policy.name))
-          policy.id = next(alert['id'] for alert in newrelic.all_alerts if alert['name'] == policy.name)
-          policy.notification_channels = self.all_notification_channels[self.context.env]
-          policy.conditions = newrelic.get_policy_alert_conditions(policy.id)
-          policy.config_conditions = deepcopy(self.conditions)
-
-          # Add alert policy to notification channels if missing
-          for channel in newrelic.all_channels:
-            if channel['name'] in policy.notification_channels and policy.id not in channel['links']['policy_ids']:
-              newrelic.add_policy_channels(policy.id, [channel['id']])
-              logger.info("add channel_ids {} to policy {}".format(policy.name, channel['id']))
-
-          # Replace symbols in config alert conditions
-          for key, value in policy.config_conditions.items():
-            policy.config_conditions[key] = self.replace_symbols(value, policy.symbols)
-
-          # Update policy.config_conditions with overrides from service_registry
-          for condition_name, override_obj in service_alert_overrides.items():
-            if condition_name in policy.config_conditions.keys():
-              for override_key, override_value in override_obj.items():
-                if isinstance(override_value, dict):
-                  for inner_key, inner_val in override_value.items():
-                    policy.config_conditions[condition_name][override_key][inner_key] = inner_val
-                else:
-                  policy.config_conditions[condition_name][override_key] = override_value
-          logger.debug("Policy {} alert condition values:\n{}".format(policy.name, policy.config_conditions))
-
-          # Remove conditions with values that differ from config
-          for condition in policy.conditions:
-            if condition['name'] in policy.config_conditions:
-              config_condition = policy.config_conditions[condition['name']]
-              for k, v in config_condition.items():
-                if condition[k] != v:
-                  newrelic.delete_policy_alert_condition(condition['id'])
-                  policy.conditions = newrelic.get_policy_alert_conditions(policy.id)
-                  logger.info("delete condition {} from policy {}. ".format(condition['name'], policy.name) + \
-                              "current value differs from config")
-                  break
-
-          # Create alert conditions for policies
-          for key, value in policy.config_conditions.items():
-            if not any(d['name'] == key for d in policy.conditions):
-              newrelic.create_alert_cond(policy.config_conditions[key])
-              logger.info("create condition {} for policy {}".format(key, policy.name))
+    if "prod" in self.context.env:
+      self.update_cloudfront_policy(self.admin_token)


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-14634](https://ellation.atlassian.net/browse/OPS-14634)

# Details
Implemented the `ef-generate` feature to create Cloudfront Alert policy in NewRelic for `prod` environment. 

This differs from service alert policy because all Cloudfront distributions are placed under one NewRelic Alert policy and for each CF distribution ef-generate creates 2 conditions:
* 4xx errors
* 5xx errors

For reference, I've used VOD CloudFront conditions. 

# Testing
Alert policy created https://alerts.newrelic.com/accounts/1354009/policies/674807