### PR TITLE
OPS-14807 Implement repository parsing by service name

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -816,7 +816,7 @@ class EFAwsResolver(object):
   def ecr_repository_uri(self, lookup, default=None):
     """
     Args:
-      lookup: the arn of the Docker image to look up
+      lookup: the name of the Docker image to look up
       default: the optional value to return if lookup failed; returns None if not set
     Returns:
       The id of the first image found with a label matching 'lookup' or default/None if no match found

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -363,7 +363,7 @@ class EFAwsResolver(object):
     ])
     if len(vpc_endpoints.get("VpcEndpoints")) < 1:
       return default
-    
+
     oldest = None
     for vpce in vpc_endpoints.get("VpcEndpoints"):
       if oldest is None or vpce["CreationTimestamp"] < oldest["CreationTimestamp"]:
@@ -774,7 +774,7 @@ class EFAwsResolver(object):
     resource_shares = EFAwsResolver.__CLIENTS["ram"].get_resource_shares(
       resourceOwner="OTHER-ACCOUNTS",
       name=lookup)
-    
+
     if len(resource_shares.get("resourceShares")) > 0:
       return resource_shares["resourceShares"][0]["resourceShareArn"]
     else:
@@ -783,7 +783,7 @@ class EFAwsResolver(object):
   def ram_resource_arn(self, lookup, default=None):
     """
     Args:
-      lookup: the resource share arn to look up 
+      lookup: the resource share arn to look up
       default: the optional value to return if lookup failed; returns None if not set
     Returns:
       The arn of the first resource found with a label matching 'lookup' or default/None if no match found
@@ -791,7 +791,7 @@ class EFAwsResolver(object):
     resources = EFAwsResolver.__CLIENTS["ram"].list_resources(
       resourceOwner="OTHER-ACCOUNTS",
       resourceShareArns=[lookup])
-    
+
     if len(resources.get("resources")) > 0:
       return resources["resources"][0]["arn"]
     else:
@@ -806,10 +806,18 @@ class EFAwsResolver(object):
       The id of the first transit gateway found with a label matching 'lookup' or default/None if no match found
     """
     transit_gateways = EFAwsResolver.__CLIENTS["ec2"].describe_transit_gateways()
-    
+
     if len(transit_gateways.get("TransitGateways")) > 0:
       transit_gateways = [i for i in transit_gateways["TransitGateways"] if (i["TransitGatewayArn"] == lookup)]
       return transit_gateways[0]["TransitGatewayId"]
+    else:
+      return default
+
+  def ecr_repository_image_name(self, lookup, default=None):
+    repositories = EFAwsResolver.__CLIENTS["ecr"].describe_repositories(repositoryNames=[ lookup ])
+
+    if len(repositories.get("repositories")) > 0:
+      return repositories.get("repositories")[0]["repositoryUri"]
     else:
       return default
 
@@ -868,6 +876,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_endpoint_id_by_vpc_service(*kv[1:])
     elif kv[0] == "ec2:vpc/vpn-gateway-id":
       return self.ec2_vpc_vpn_gateway_id(*kv[1:])
+    elif kv[0] == "ecr:repository/image-name":
+      return self.ecr_repository_image_name(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/dns-name":
       return self.elbv2_load_balancer_dns_name(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/hosted-zone":

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -814,6 +814,13 @@ class EFAwsResolver(object):
       return default
 
   def ecr_repository_image_name(self, lookup, default=None):
+    """
+    Args:
+      lookup: the arn of the Docker image to look up
+      default: the optional value to return if lookup failed; returns None if not set
+    Returns:
+      The id of the first image found with a label matching 'lookup' or default/None if no match found
+    """
     repositories = EFAwsResolver.__CLIENTS["ecr"].describe_repositories(repositoryNames=[ lookup ])
 
     if len(repositories.get("repositories")) > 0:

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -813,7 +813,7 @@ class EFAwsResolver(object):
     else:
       return default
 
-  def ecr_repository_image_name(self, lookup, default=None):
+  def ecr_repository_uri(self, lookup, default=None):
     """
     Args:
       lookup: the arn of the Docker image to look up
@@ -883,8 +883,8 @@ class EFAwsResolver(object):
       return self.ec2_vpc_endpoint_id_by_vpc_service(*kv[1:])
     elif kv[0] == "ec2:vpc/vpn-gateway-id":
       return self.ec2_vpc_vpn_gateway_id(*kv[1:])
-    elif kv[0] == "ecr:repository/image-name":
-      return self.ecr_repository_image_name(*kv[1:])
+    elif kv[0] == "ecr:repository/repository-uri":
+      return self.ecr_repository_uri(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/dns-name":
       return self.elbv2_load_balancer_dns_name(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/hosted-zone":

--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -821,11 +821,13 @@ class EFAwsResolver(object):
     Returns:
       The id of the first image found with a label matching 'lookup' or default/None if no match found
     """
-    repositories = EFAwsResolver.__CLIENTS["ecr"].describe_repositories(repositoryNames=[ lookup ])
-
-    if len(repositories.get("repositories")) > 0:
-      return repositories.get("repositories")[0]["repositoryUri"]
-    else:
+    try:
+      repositories = EFAwsResolver.__CLIENTS["ecr"].describe_repositories(repositoryNames=[ lookup ])
+      if len(repositories.get("repositories")) > 0:
+        return repositories.get("repositories")[0]["repositoryUri"]
+      else:
+        return default
+    except ClientError:
       return default
 
   def lookup(self, token):

--- a/efopen/ef_config.py
+++ b/efopen/ef_config.py
@@ -100,9 +100,9 @@ class EFConfig(object):
           "allow_latest": True,
           "allowed_types": ["aws_ec2", "http_service"]
       },
-      "image-id": {
+      "image-tag": {
         "allow_latest": True,
-        "allowed_types": ["aws_ec2", "http_service"]
+        "allowed_types": ["http_service"]
       },
       "config": {},
       "dist-hash": {

--- a/efopen/ef_config.py
+++ b/efopen/ef_config.py
@@ -100,6 +100,10 @@ class EFConfig(object):
           "allow_latest": True,
           "allowed_types": ["aws_ec2", "http_service"]
       },
+      "image-id": {
+        "allow_latest": True,
+        "allowed_types": ["aws_ec2", "http_service"]
+      },
       "config": {},
       "dist-hash": {
           "allowed_types": ["dist_static", "aws_lambda"]

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -76,7 +76,7 @@ SERVICE_TYPE_ROLE = {
   "aws_ec2": "ec2.amazonaws.com",
   "aws_lambda": "lambda.amazonaws.com",
   "aws_role": None, # Bare role requires a custom assume role policy ("assume_role_policy": "name_of_policy")
-  "http_service": ["ec2.amazonaws.com", "ecs-tasks.amazonaws.com", "ecs-tasks.amazonaws.com"]
+  "http_service": ["ec2.amazonaws.com", "ecs.amazonaws.com", "ecs-tasks.amazonaws.com"]
 }
 
 # these service types get Security Groups

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -76,7 +76,7 @@ SERVICE_TYPE_ROLE = {
   "aws_ec2": "ec2.amazonaws.com",
   "aws_lambda": "lambda.amazonaws.com",
   "aws_role": None, # Bare role requires a custom assume role policy ("assume_role_policy": "name_of_policy")
-  "http_service": "ec2.amazonaws.com"
+  "http_service": ["ec2.amazonaws.com", "ecs-tasks.amazonaws.com", "ecs-tasks.amazonaws.com"]
 }
 
 # these service types get Security Groups

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -233,6 +233,7 @@ class EFTemplateResolver(object):
       "cognito-identity",
       "cognito-idp",
       "ec2",
+      "ecr",
       "elbv2",
       "iam",
       "kms",

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -2356,10 +2356,17 @@ class TestEFAwsResolver(unittest.TestCase):
     """
     image_name = "service-ecr"
     repository_uri = 'account-id.dkr.ecr.us-west-2.amazonaws.com/{}'.format(image_name)
-    self._clients["ecr"].describe_repositories.return_value = \
+    self._clients["ecr"].describe_repositories.side_effect = ClientError(
       {
-        'repositories': []
-      }
+        'Error':
+          {
+            'Code': 400,
+            'Message': "The specified repository could not be found.",
+            'Type': "RepositoryNotFoundException"
+          }
+      },
+      'describe_repositories'
+    )
     ef_aws_resolver = EFAwsResolver(self._clients)
     self.assertIsNone(ef_aws_resolver.lookup("ecr:repository/repository-uri,%s" % image_name))
 

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -2339,7 +2339,7 @@ class TestEFAwsResolver(unittest.TestCase):
     self._clients["ecr"].describe_repositories.return_value = \
       {
         'repositories': [{
-          'repositoryArn': 'arn:aws:ecr:region:account-id:respository/{}'.format(image_name),
+          'repositoryArn': 'arn:aws:ecr:region:account-id:repository/{}'.format(image_name),
           'repositoryName': image_name,
           'repositoryUri': repository_uri,
         }]

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -2330,7 +2330,7 @@ class TestEFAwsResolver(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       ef_aws_resolver.lookup("kms:key_arn,alias/key_no_exist")
 
-  def test_ecr_repository_image_name(self):
+  def test_ecr_repository_uri(self):
     """
     Tests for ECR Image name lookup
     """
@@ -2346,11 +2346,11 @@ class TestEFAwsResolver(unittest.TestCase):
       }
     ef_aws_resolver = EFAwsResolver(self._clients)
     self.assertEqual(
-      ef_aws_resolver.lookup("ecr:repository/image-name,%s" % image_name),
+      ef_aws_resolver.lookup("ecr:repository/repository-uri,%s" % image_name),
       repository_uri
     )
 
-  def test_ecr_repository_image_name_no_such_repository(self):
+  def test_ecr_repository_uri_no_such_repository(self):
     """
     Tests for ECR Image name lookup
     """
@@ -2361,7 +2361,7 @@ class TestEFAwsResolver(unittest.TestCase):
         'repositories': []
       }
     ef_aws_resolver = EFAwsResolver(self._clients)
-    self.assertIsNone(ef_aws_resolver.lookup("ecr:repository/image-name,%s" % image_name))
+    self.assertIsNone(ef_aws_resolver.lookup("ecr:repository/repository-uri,%s" % image_name))
 
   def test_elbv2_load_balancer_hosted_zone(self):
     """

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -46,6 +46,7 @@ class TestEFAwsResolver(unittest.TestCase):
     mock_cognito_identity_client = Mock(name="Mock Cognito Identity Client")
     mock_cognito_idp_client = Mock(name="Mock Cognito IDP Client")
     mock_ec2_client = Mock(name="Mock EC2 Client")
+    mock_ecr_client = Mock(name="Mock ECR Client")
     mock_route_53_client = Mock(name="Mock Route 53 Client")
     mock_waf_client = Mock(name="Mock WAF Client")
     mock_session = Mock(name="Mock Client")
@@ -59,6 +60,7 @@ class TestEFAwsResolver(unittest.TestCase):
       "cognito-identity": mock_cognito_identity_client,
       "cognito-idp": mock_cognito_idp_client,
       "ec2": mock_ec2_client,
+      "ecr": mock_ecr_client,
       "route53": mock_route_53_client,
       "waf": mock_waf_client,
       "SESSION": mock_session,
@@ -665,7 +667,7 @@ class TestEFAwsResolver(unittest.TestCase):
     ef_aws_resolver = EFAwsResolver(self._clients)
     result = ef_aws_resolver.lookup("ec2:subnet/subnet-id,cant_possibly_match")
     self.assertIsNone(result)
-  
+
   def test_ec2_transit_gateway_id(self):
     """
     Tests ec2_transit_gateway_id to see if it returns a transit gateway id based on matching transit gateway arn
@@ -914,7 +916,7 @@ class TestEFAwsResolver(unittest.TestCase):
 
   def test_ec2_vpc_endpoint_id(self):
     """
-    Tests that this function returns the vpc endpoint id when it finds a 
+    Tests that this function returns the vpc endpoint id when it finds a
     resource with the right tag.
 
     Returns:
@@ -2327,6 +2329,39 @@ class TestEFAwsResolver(unittest.TestCase):
     ef_aws_resolver = EFAwsResolver(self._clients)
     with self.assertRaises(RuntimeError):
       ef_aws_resolver.lookup("kms:key_arn,alias/key_no_exist")
+
+  def test_ecr_repository_image_name(self):
+    """
+    Tests for ECR Image name lookup
+    """
+    image_name = "service-ecr"
+    repository_uri = 'account-id.dkr.ecr.us-west-2.amazonaws.com/{}'.format(image_name)
+    self._clients["ecr"].describe_repositories.return_value = \
+      {
+        'repositories': [{
+          'repositoryArn': 'arn:aws:ecr:region:account-id:respository/{}'.format(image_name),
+          'repositoryName': image_name,
+          'repositoryUri': repository_uri,
+        }]
+      }
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    self.assertEqual(
+      ef_aws_resolver.lookup("ecr:repository/image-name,%s" % image_name),
+      repository_uri
+    )
+
+  def test_ecr_repository_image_name_no_such_repository(self):
+    """
+    Tests for ECR Image name lookup
+    """
+    image_name = "service-ecr"
+    repository_uri = 'account-id.dkr.ecr.us-west-2.amazonaws.com/{}'.format(image_name)
+    self._clients["ecr"].describe_repositories.return_value = \
+      {
+        'repositories': []
+      }
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    self.assertIsNone(ef_aws_resolver.lookup("ecr:repository/image-name,%s" % image_name))
 
   def test_elbv2_load_balancer_hosted_zone(self):
     """


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-14807](https://ellation.atlassian.net/browse/OPS-14807)

# Details
Implement the functionality for parsing the following syntax, in order to support ECS in ETPv1:
`{{aws:ecr:repository/image-name,{{ENV}}-{{SERVICE}}-ecr}}`
Any improvements are welcome.

# Testing
Automated tests implemented and deployment made using this version of ef-open