### PR TITLE
Disable pylint in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
       - run:
           command: python -m unittest discover
           name: Unit Tests
-      - run:
-          command: pylint --rcfile=./pylintrc --disable=C,W,R ./efopen
-          name: Pylint
 workflows:
   main:
     jobs:


### PR DESCRIPTION
# Ready State and Ticket
**Ready**
[OPS-14927](https://ellation.atlassian.net/browse/OPS-14927)

# Details
Disable pylinting because it runs with disabled for many coding convention errors