### PR TITLE
OPS-15043-v2 Safe lookup for new relic settings

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -14,10 +14,10 @@ class NewRelicAlerts(object):
 
   def __init__(self, context, clients):
     self.config = EFConfig.PLUGINS['newrelic']
-    self.conditions = self.config['alert_conditions']
-    self.local_alert_nrql_conditions = self.config['alert_nrql_conditions']
-    self.admin_token = self.config['admin_token']
-    self.all_notification_channels = self.config['env_notification_map']
+    self.conditions = self.config.get('alert_conditions', {})
+    self.local_alert_nrql_conditions = self.config.get('alert_nrql_conditions', {})
+    self.admin_token = self.config.get('admin_token', "")
+    self.all_notification_channels = self.config.get('env_notification_map', {})
     self.context, self.clients = context, clients
 
   @classmethod


### PR DESCRIPTION
# Ready State and Ticket
[OPS-15043](https://ellation.atlassian.net/browse/OPS-15043)

# Details
with the additional of a new field, there's a chance for the ef-open code to blow up if the dictionary key isn't there

Should instead do a safe lookup and if there's nothing there, nothihng bad happens with ef-generate calling newrelic_executor
