### PR TITLE
OPS-15202 Unescape escaped sequences in args

### DIFF
--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -173,7 +173,11 @@ def handle_args_and_set_context(args):
   context.service = parsed_args["service"]
   context.decrypt = parsed_args["decrypt"]
   context.length = parsed_args["length"]
-  context.plaintext = parsed_args["plaintext"]
+
+  # When called from bash in this form `ef-password --plaintext "hello\nworld"`
+  # the OS transforms the plaintext argument into `"hello\\nworld"`,
+  # resulting in unexpected results on decryption
+  context.plaintext = parsed_args["plaintext"].decode("string_escape")
   context.secret_file = parsed_args["secret_file"]
   context.match = parsed_args["match"]
   if context.match or context.secret_file:

--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -173,10 +173,7 @@ def handle_args_and_set_context(args):
   context.service = parsed_args["service"]
   context.decrypt = parsed_args["decrypt"]
   context.length = parsed_args["length"]
-
-  # When called from bash in this form `ef-password --plaintext "hello\nworld"`
-  # the OS transforms the plaintext argument into `"hello\\nworld"`,
-  # resulting in unexpected results on decryption
+  # unescape any escapes that the shell might've added; e.g: \\n becomes \n
   context.plaintext = parsed_args["plaintext"].decode("string_escape")
   context.secret_file = parsed_args["secret_file"]
   context.match = parsed_args["match"]

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -69,6 +69,21 @@ class TestEFPassword(unittest.TestCase):
     self.assertEqual(context.length, 10)
     self.assertEqual(context.plaintext, "test")
 
+  def test_args_plaintext_escape_sequences(self):
+    """
+    Test parsing args with all valid values and plaintext with escape sequences
+    When called from bash in this form `ef-password --plaintext "hello\nworld"`
+    the OS transforms the plaintext argument into `"hello\\nworld"`,
+    resulting in unexpected results on decryption
+    """
+    expected_plaintext = "hello\nworld"
+    args = [self.service, self.env, "--length", "10", "--plaintext", "hello\\nworld"]
+    context = ef_password.handle_args_and_set_context(args)
+    self.assertEqual(context.env, self.env)
+    self.assertEqual(context.service, self.service)
+    self.assertEqual(context.length, 10)
+    self.assertEqual(context.plaintext, expected_plaintext)
+
   def test_args_secret_file(self):
     """Test parsing args with all valid values (secret file)"""
     args = [self.service, self.env, "--length", "10", "--secret_file",


### PR DESCRIPTION
# Ready State and Ticket

**Ready**
[OPS-15202](https://ellation.atlassian.net/browse/OPS-15202)

# Details
There was an issue with ef-password such as when called from bash in the form `ef-password --plaintext "hello\nworld"` the OS transforms the plaintext argument into `"hello\\nworld"`, resulting in unexpected results on decryption

The most proeminent issue is that on decryption `hello\nworld` resolves as `hello\nworld` instead of 
```
hello
world
```