### PR TITLE
OPS-15109 Update ef-generate to enable KMS key rotation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,4 @@
-# Ready State and Ticket
-> Valid states are:
-> Ready - This PR is ready to be reviewed.
-> Not Ready - Please provide an explanation below.
-**Ready**
+# Ticket
 [OPS-XXXXX](https://ellation.atlassian.net/browse/OPS-XXXXX)
 
 # Details


### PR DESCRIPTION
# Ticket
[OPS-15109](https://ellation.atlassian.net/browse/OPS-15109)

# Details
Update ef-generate to enable KMS key rotation
Updated the ef-generate unit tests to check that enable_key_rotation is always called
Update the pull request template
