### PR TITLE
update allowed_types for image-tag version key

### DIFF
--- a/efopen/ef_config.py
+++ b/efopen/ef_config.py
@@ -102,7 +102,7 @@ class EFConfig(object):
       },
       "image-tag": {
         "allow_latest": True,
-        "allowed_types": ["http_service"]
+        "allowed_types": ["aws_ecs", "aws_ecs_http"]
       },
       "config": {},
       "dist-hash": {


### PR DESCRIPTION

# Details
Update the 'image-tag' ef-version key to support the newer aws_ecs and aws_ecs_http types