### PR TITLE
OPS-15344 make ef-generate working for prod without cloudfront

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -217,6 +217,6 @@ class NewRelicAlerts(object):
       self.newrelic = NewRelic(self.admin_token)
       self.update_application_services_policies()
 
-      # Fix the cloudfront code
+      # TODO: Fix the cloudfront code
       # if self.context.env in ["prod"]:
       #  self.update_cloudfront_policy()

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -63,7 +63,7 @@ class NewRelicAlerts(object):
           if condition[k] != v:
             self.newrelic.delete_policy_alert_condition(condition['id'])
             policy.remote_conditions = self.newrelic.get_policy_alert_conditions(policy.id)
-            logger.info("delete condition {} from policy {}. ".format(condition['name'], policy.name) + \
+            logger.info("delete condition {} from policy {}. ".format(condition['name'], policy.name) +
                         "current value differs from config")
             break
 
@@ -123,9 +123,9 @@ class NewRelicAlerts(object):
 
     conditions = {}
     for id, alias in queue:
-      conditions['cloudfront-{}-{}'.format(id, '4xxErrorRate')] = meta(
+      conditions['4xx Average {}'.format(alias)] = meta(
         '4xxErrorRate', 10, id, '4xx Average {}'.format(alias), policy.id)
-      conditions['cloudfront-{}-{}'.format(id, '5xxErrorRate')] = meta(
+      conditions['5xx Average {}'.format(alias)] = meta(
         '5xxErrorRate', 5, id, '5xx Average {}'.format(alias), policy.id)
 
     policy.config_conditions = deepcopy(conditions)
@@ -217,5 +217,6 @@ class NewRelicAlerts(object):
       self.newrelic = NewRelic(self.admin_token)
       self.update_application_services_policies()
 
-      if self.context.env in ["prod"]:
-        self.update_cloudfront_policy()
+      # Fix the cloudfront code
+      # if self.context.env in ["prod"]:
+      #  self.update_cloudfront_policy()

--- a/efopen/newrelic_interface.py
+++ b/efopen/newrelic_interface.py
@@ -95,6 +95,15 @@ class NewRelic(object):
       try:
         endpoint_url = r.links['next']['url']
       except KeyError:
+        # TODO - uncomment this when working on cloudfront feature, the response has the links inside the content String
+        # and not a separate field as expected above
+        # Calls to the cloudfront alert policies for some reason have the links and next inside the content
+        # instead of the links field in the dictionary
+        # try:
+        #   json_response = json.loads(r.content)
+        #   endpoint_url = json_response['links']['next']
+        # except KeyError:
+        #   break
         break
     return response
 


### PR DESCRIPTION
# Ticket
[OPS-15344](https://ellation.atlassian.net/browse/OPS-15344)

# Details
Couple of issues with the cloudfront cod
- condition names that were created didn't match what it was checking if it didn't exist or not, so for cloudfront it kept always creating alert conditions til it hit the 500 limit, so named it so it would match
- the get call in newrelic_interface for GET would not handle the response correctly with prod-cloudfront, the links is inside the response string, not a separate field in the dict object. This only occurs calling cloudfront, the other alerts work as expected
- 'select_value': 'provider.{}.Average'.format(error_rate), line 93 in newrelic_executor is an invalid value, need to look up what the correct value is
