### PR TITLE
MORT-1148 remove ec2.describe-instance api calls

### DIFF
--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -351,27 +351,3 @@ def get_autoscaling_group_properties(asg_client, env, service):
       return response["AutoScalingGroups"]
   except ClientError as error:
     raise RuntimeError("Error in finding autoscaling group {} {}".format(env, service), error)
-
-def get_instance_aws_context(ec2_client): # marked, not used
-  """
-  Returns: a dictionary of aws context
-    dictionary will contain these entries:
-    region, instance_id, account, role, env, env_short, service
-  Raises: IOError if couldn't read metadata or lookup attempt failed
-  """
-  result = {}
-  try:
-    result["region"] = http_get_metadata("placement/availability-zone/")
-    result["region"] = result["region"][:-1]
-    result["instance_id"] = http_get_metadata('instance-id')
-  except IOError as error:
-    raise IOError("Error looking up metadata:availability-zone or instance-id: " + repr(error))
-  try:
-    instance_desc = ec2_client.describe_instances(InstanceIds=[result["instance_id"]])
-  except Exception as error:
-    raise IOError("Error calling describe_instances: " + repr(error))
-  result["account"] = instance_desc["Reservations"][0]["OwnerId"]
-  arn = instance_desc["Reservations"][0]["Instances"][0]["IamInstanceProfile"]["Arn"]
-  result["role"] = arn.split(":")[5].split("/")[1]
-  result["service"] = "-".join(result["role"].split("-")[1:])
-  return result

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -379,65 +379,6 @@ class TestEFUtils(unittest.TestCase):
       ef_utils.http_get_instance_role()
     self.assertIn("Error looking up metadata:iam/info:", str(exception.exception))
 
-  @patch('ef_utils.http_get_metadata')
-  def test_get_instance_aws_context(self, mock_http_get_metadata):
-    """
-    Tests get_instance_aws_context to see if it produces a dict object with all the
-    data supplied in the metadata.
-
-    Args:
-      mock_http_get_metadata: MagicMock, returns valid responses in the order its called
-
-    Returns:
-      None
-
-    Raises:
-      AssertionError if any of the assert checks fail
-    """
-    mock_http_get_metadata.side_effect = ["us-west-2a", "i-00001111f"]
-    mock_ec2_client = Mock(name="mock-ec2-client")
-    mock_ec2_client.describe_instances.return_value = \
-      {
-        "Reservations": [
-          {
-            "OwnerId": "4444",
-            "Instances": [
-              {
-                "IamInstanceProfile": {
-                  "Arn": "arn:aws:iam::1234:instance-profile/alpha0-server-ftp"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    result = ef_utils.get_instance_aws_context(mock_ec2_client)
-    self.assertEquals(result["account"], "4444")
-    self.assertEquals(result["instance_id"], "i-00001111f")
-    self.assertEquals(result["region"], "us-west-2")
-    self.assertEquals(result["role"], "alpha0-server-ftp")
-    self.assertEquals(result["service"], "server-ftp")
-
-  @patch('ef_utils.http_get_metadata')
-  def test_get_instance_aws_context_metadata_exception(self, mock_http_get_metadata):
-    """
-    Tests get_instance_aws_context to see if it throws an exception by giving it invalid metadata
-
-    Args:
-      mock_http_get_metadata: MagicMock, throws an IOError exception
-
-    Returns:
-      None
-
-    Raises:
-      AssertionError if any of the assert checks fail
-    """
-    mock_http_get_metadata.side_effect = IOError("No data")
-    mock_ec2_client = Mock(name="mock-ec2-client")
-    with self.assertRaises(IOError) as exception:
-      ef_utils.get_instance_aws_context(mock_ec2_client)
-    self.assertIn("Error looking up metadata:availability-zone or instance-id:", str(exception.exception))
-
   @patch('boto3.Session')
   def test_create_aws_clients(self, mock_session_constructor):
     """


### PR DESCRIPTION
# Ticket
[MORT-1148](https://ellation.atlassian.net/browse/MORT-1148)

# Details
Removes the ec2.describe-instance api calls being made during instance boot. We've seen this get throttled by the aws api during large scaling events, which then causes ef-init to fail. 

Deleted ef_utils.get_instance_aws_context and associated tests as it is not used anywhere in the code.

For the purposes of code review, here is an example profile_arn `"arn:aws:iam::366843697376:instance-profile/staging-test-instance"`

# Testing
Tested by manually modifying the ef-open code on a proto0-test-instance machine due to the requirements around running on an actual ec2 instance rather than locally. 