### PR TITLE
OPS-15355 Fix Cloudfront alerts creation

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -122,6 +122,7 @@ class NewRelicAlerts(object):
       logger.info("create alert policy {}".format(policy.name))
 
     self.populate_alert_policy_values(policy)
+    self.add_alert_policy_to_notification_channels(policy)
 
     conditions = {}
     for id, alias in queue:

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -124,9 +124,9 @@ class NewRelicAlerts(object):
     conditions = {}
     for id, alias in queue:
       conditions['4xx Average {}'.format(alias)] = meta(
-        '4xxErrorRate', 10, id, '4xx Average {}'.format(alias), policy.id)
+        'error4xxErrorRate', 10, id, '4xx Average {}'.format(alias), policy.id)
       conditions['5xx Average {}'.format(alias)] = meta(
-        '5xxErrorRate', 5, id, '5xx Average {}'.format(alias), policy.id)
+        'error5xxErrorRate', 5, id, '5xx Average {}'.format(alias), policy.id)
 
     policy.config_conditions = deepcopy(conditions)
 

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -131,7 +131,6 @@ class NewRelicAlerts(object):
         'error5xxErrorRate', 5, id, '5xx Average {}'.format(alias), policy.id)
 
     policy.config_conditions = deepcopy(conditions)
-
     # Infra alert conditions
     policy = self.delete_conditions_not_matching_config_values(policy)
     self.create_infra_alert_conditions(policy)
@@ -219,6 +218,5 @@ class NewRelicAlerts(object):
       self.newrelic = NewRelic(self.admin_token)
       self.update_application_services_policies()
 
-      # TODO: Fix the cloudfront code
-      # if self.context.env in ["prod"]:
-      #  self.update_cloudfront_policy()
+      if self.context.env in ["prod"]:
+        self.update_cloudfront_policy()

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -71,10 +71,12 @@ class NewRelicAlerts(object):
 
   def create_infra_alert_conditions(self, policy):
     # Create alert conditions for policies
-    for key, value in policy.config_conditions.items():
-      if not any(condition['name'] == key for condition in policy.remote_conditions):
-        self.newrelic.create_alert_condition(policy.config_conditions[key])
-        logger.info("create condition {} for policy {}".format(key, policy.name))
+    remote_conditions = set([condition['name'] for condition in policy.remote_conditions])
+    conditions_to_create = set(policy.config_conditions.keys()).difference(remote_conditions)
+
+    for key in conditions_to_create:
+      self.newrelic.create_alert_condition(policy.config_conditions[key])
+      logger.info("create condition {} for policy {}".format(key, policy.name))
 
   def update_cloudfront_policy(self):
     # Update Cloudfront alert policies

--- a/efopen/newrelic_interface.py
+++ b/efopen/newrelic_interface.py
@@ -95,16 +95,17 @@ class NewRelic(object):
       try:
         endpoint_url = r.links['next']['url']
       except KeyError:
-        # TODO - uncomment this when working on cloudfront feature, the response has the links inside the content String
-        # and not a separate field as expected above
-        # Calls to the cloudfront alert policies for some reason have the links and next inside the content
-        # instead of the links field in the dictionary
-        # try:
-        #   json_response = json.loads(r.content)
-        #   endpoint_url = json_response['links']['next']
-        # except KeyError:
-        #   break
-        break
+        # This parameter comes only on GET https://infra-api.newrelic.com/v2/alerts/conditions
+        if 'meta' not in r.json():
+          break
+
+        meta = r.json()['meta']
+
+        new_offset = meta['offset'] + meta['limit']
+        if new_offset < meta['total']:
+          params['offset'] = new_offset
+        else:
+          break
     return response
 
   def refresh_alert_policies(self):


### PR DESCRIPTION
# Ticket
[OPS-15355](https://ellation.atlassian.net/browse/OPS-15355)

# Details
The root cause was that fetching all alert conditions was not correctly implemented. Currently, the link provided by alert conditions GET request does not work anymore so using params to adjust offset seems to be a better solution.

Besides that, the NewRelic documentation states([link](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration#metrics)) that we can use:
* `4xxErrorRate`
* `5xxErrorRate`
But their UI is not behaving properly and these metric keys are not correct. Had to look into their HTML page to fix this issue.

Also, optimized `create_infra_alert_conditions` method to avoid iteration over `policy.remote_conditions` for each `policy.config_conditions`.

# Testing
Everything seems to work, for the moment.

Scenarios tested:
* Delete `staging-test-instance` alert policy's, run `ef-generate staging`, alert `staging-test-instance` is created with all conditions
* Delete `staging-test-instance` alert policy's condition `disk_usage`, run 'ef-generate staging`, condition is created
* Modify `staging-test-instance` alert policy's condition `disk_usage`, condition is removed from NewRelic, then added again with correct values
* Deleted `prod-cloudfront` alert policy, all `76` rules are created(36 distributions * 2 conditions)
* Modify `prod-cloudfront` alert policy's condition `5xx beta.crunchyroll.com` with a greater value for period, alert got deleted and added again.
```
➜  ellation_formation git:(master) ✗ ef-generate prod
=== DRY RUN ===
Use --commit to create roles and security groups
=== DRY RUN ===
env: prod
env_full: prod
env_short: prod
aws account profile: ellation
aws account number: 978969509086
> Creating NewRelic Alerts
INFO:efopen.newrelic_executor:update cloudfront alert policy
INFO:efopen.newrelic_executor:delete condition 5xx Average beta-api.crunchyroll.com from policy prod-cloudfront. current value differs from config
INFO:efopen.newrelic_executor:create condition 5xx Average beta-api.crunchyroll.com for policy prod-cloudfront
Exit: success
```