### PR TITLE
fix service symbol on ec2

### DIFF
--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -282,7 +282,7 @@ class EFTemplateResolver(object):
       self.resolved["ACCOUNT"] = profile_arn.split(":")[4]
       self.resolved["ROLE"] = profile_arn.split("/")[-1]
       self.resolved["ENV"] = self.resolved["ROLE"].split("-")[0]
-      self.resolved["SERVICE"] = "-".join(profile_arn.split("-")[1:])
+      self.resolved["SERVICE"] = "-".join(self.resolved["ROLE"].split("-")[1:])
 
     # target is "other"
     else:


### PR DESCRIPTION
# Details
Fixes a bug with the `SERVICE` symbol introduced in PR https://github.com/crunchyroll/ef-open/pull/185 

Sample `profile_arn` : `arn:aws:iam::366843697376:instance-profile/staging-test-instance`

# Testing
Made changes locally on a proto0 test-instance and re-ran ef-init. Specifially looking for usage of the `SERVICE` symbol

## template (raw)
![image](https://user-images.githubusercontent.com/7519487/87175491-8ffb2680-c28d-11ea-897d-6de843a30eaa.png)


## template (resolved)
![image](https://user-images.githubusercontent.com/7519487/87175388-6e01a400-c28d-11ea-8d5e-da15e347927d.png)

## all symbols
![image](https://user-images.githubusercontent.com/7519487/87177083-e9fceb80-c28f-11ea-89ef-7b4d7b795210.png)

