### PR TITLE
OPS-15506 Skip template symbols in order to perform CI into unauthorized environments

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -123,7 +123,7 @@ def handle_args_and_set_context(args):
                       type=int, default=False)
   parser.add_argument("--poll", help="Poll Cloudformation to check status of stack creation/updates",
                       action="store_true", default=False)
-  parser.add_argument("--skip_symbols", help="Skip resolving the provided symbols", nargs='+')
+  parser.add_argument("--skip_symbols", help="Skip resolving the provided symbols", nargs='+', default=[])
   parsed_args = vars(parser.parse_args(args))
   context = EFCFContext()
   try:
@@ -147,10 +147,10 @@ def resolve_template(template, profile, env, region, service, skip_symbols, verb
   # resolve {{SYMBOLS}} in the passed template file
   os.path.isfile(template) or fail("Not a file: {}".format(template))
   resolver = EFTemplateResolver(profile=profile, target_other=True, env=env,
-                                region=region, service=service, verbose=verbose)
+                                region=region, service=service, skip_symbols=skip_symbols, verbose=verbose)
   with open(template) as template_file:
     resolver.load(template_file)
-    resolver.render(skip_symbols=skip_symbols)
+    resolver.render()
 
   if verbose:
     print(resolver.template)

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -389,7 +389,7 @@ class EFTemplateResolver(object):
       result = self.parameters[self.resolved["ENV_FULL"]][symbol]
     return result
 
-  def render(self):
+  def render(self, skip_symbols={}):
     """
     Find {{}} tokens; resolve then replace them as described elsewhere
     Resolution is multi-pass: tokens may be nested to form parts of other tokens.
@@ -413,8 +413,12 @@ class EFTemplateResolver(object):
       # resolve and replace symbols
       for symbol in template_symbols:
         resolved_symbol = None
+
+        # Don't resolve symbols that are provided as skippable
+        if symbol.split(',')[0] in skip_symbols:
+          continue
         # Lookups in AWS, only if we have an EFAwsResolver
-        if symbol[:4] == "aws:" and EFTemplateResolver.__AWSR:
+        elif symbol[:4] == "aws:" and EFTemplateResolver.__AWSR:
           resolved_symbol = EFTemplateResolver.__AWSR.lookup(symbol[4:])
         # Lookups in credentials
         elif symbol[:12] == "credentials:":

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -120,6 +120,7 @@ class EFTemplateResolver(object):
                profile=None, region=None,  # set both for user access mode
                lambda_context=None,  # set if target is 'self' and this is a lambda
                target_other=False, env=None, service=None,  # set env & service if target_other=True
+               skip_symbols={},
                verbose=False
                ):
     """
@@ -202,6 +203,7 @@ class EFTemplateResolver(object):
     # Sets of symbols found in the current template (only)
     # read back with self.symbols() and self.unresolved_symbols()
     self.symbols = set()
+    self.skip_symbols = skip_symbols
     # capture verbosity pref from constructor
     self.verbose = verbose
 
@@ -389,7 +391,7 @@ class EFTemplateResolver(object):
       result = self.parameters[self.resolved["ENV_FULL"]][symbol]
     return result
 
-  def render(self, skip_symbols={}):
+  def render(self):
     """
     Find {{}} tokens; resolve then replace them as described elsewhere
     Resolution is multi-pass: tokens may be nested to form parts of other tokens.
@@ -415,8 +417,8 @@ class EFTemplateResolver(object):
         resolved_symbol = None
 
         # Don't resolve symbols that are provided as skippable
-        if symbol.split(',')[0] in skip_symbols:
-          continue
+        if symbol.split(',')[0] in self.skip_symbols:
+          resolved_symbol = "NONE"
         # Lookups in AWS, only if we have an EFAwsResolver
         elif symbol[:4] == "aws:" and EFTemplateResolver.__AWSR:
           resolved_symbol = EFTemplateResolver.__AWSR.lookup(symbol[4:])


### PR DESCRIPTION
# Ticket
[OPS-15506](https://ellation.atlassian.net/browse/OPS-15506)

# Details
In some unauthorized environments, the kms keys should not be decrypted to avoid any secret disclosure.

# Testing
```
➜  project git:(<branch>) ✗ ef-cf <template> <env> --devel --lint
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
not refreshing repo because --devel was set or running on Jenkins
boto3 exception occurred while performing kms decrypt operation.
ClientError(u'An error occurred (AccessDeniedException) when calling the Decrypt operation: The ciphertext refers to a customer master key that does not exist, does not exist in this region, or you are not allowed to access.',)
➜   project git:(<branch>) ✗ ef-cf <template> <env> --devel --lint --skip_symbols aws:kms:decrypt
=== DRY RUN ===
Validation only. Use --commit to push template to CF
=== DRY RUN ===
not refreshing repo because --devel was set or running on Jenkins
Template passed validation
=== CLOUDFORMATION LINTING ===
W3011 Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/Rds from deletion
.lint/template.json:379:5


Template passed CFN linting
