### PR TITLE
Ops 15630 - In order to allow session manager users to log with dev username on ec2, I need ef-generate to support tags when creating IAM roles

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -322,14 +322,9 @@ def conditionally_create_role(role_name, sr_entry, tags=None):
     print_if_verbose("AssumeRole policy document:\n{}".format(assume_role_policy_document))
     if CONTEXT.commit:
       try:
-        if tags != None:
-          new_role = CLIENTS["iam"].create_role(
-            RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document, Tags=tags
-          )
-        else:
-          new_role = CLIENTS["iam"].create_role(
-              RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document
-          )
+        new_role = CLIENTS["iam"].create_role(
+          RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document, Tags=tags or []
+        )
       except ClientError as error:
         fail("Exception creating new role named: {} {}".format(role_name, sys.exc_info(), error))
       print(new_role["Role"]["RoleId"])

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -268,7 +268,7 @@ def conditionally_create_security_groups(env, service_name, service_type):
     else:
       print_if_verbose("security group already exists: {}".format(sg_name))
 
-def conditionally_create_role(role_name, sr_entry):
+def conditionally_create_role(role_name, sr_entry, tags=None):
   """
   Create role_name if a role by that name does not already exist; attach a custom list of Principals
   to its AssumeRolePolicy
@@ -323,7 +323,7 @@ def conditionally_create_role(role_name, sr_entry):
     if CONTEXT.commit:
       try:
         new_role = CLIENTS["iam"].create_role(
-          RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document
+          RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document, Tags=tags
         )
       except ClientError as error:
         fail("Exception creating new role named: {} {}".format(role_name, sys.exc_info(), error))
@@ -688,7 +688,10 @@ def main():
 
     # 1. CONDITIONALLY MAKE ROLE AND/OR INSTANCE PROFILE FOR THE SERVICE
     # If service gets a role, create with either a custom or default AssumeRole policy document
-    conditionally_create_role(target_name, sr_entry)
+    if (sr_entry['tags']):
+      conditionally_create_role(target_name, sr_entry, tags=sr_entry['tags'])
+    else:
+      conditionally_create_role(target_name, sr_entry)
     # Instance profiles and security groups are not allowed in the global scope
     if CONTEXT.env != "global":
       conditionally_create_profile(target_name, service_type)

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -688,10 +688,7 @@ def main():
 
     # 1. CONDITIONALLY MAKE ROLE AND/OR INSTANCE PROFILE FOR THE SERVICE
     # If service gets a role, create with either a custom or default AssumeRole policy document
-    if 'tags' in sr_entry.keys():
-      conditionally_create_role(target_name, sr_entry, tags=sr_entry['tags'])
-    else:
-      conditionally_create_role(target_name, sr_entry)
+    conditionally_create_role(target_name, sr_entry, tags=sr_entry.get('tags'))
     # Instance profiles and security groups are not allowed in the global scope
     if CONTEXT.env != "global":
       conditionally_create_profile(target_name, service_type)

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -322,9 +322,14 @@ def conditionally_create_role(role_name, sr_entry, tags=None):
     print_if_verbose("AssumeRole policy document:\n{}".format(assume_role_policy_document))
     if CONTEXT.commit:
       try:
-        new_role = CLIENTS["iam"].create_role(
-          RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document, Tags=tags
-        )
+        if tags != None:
+          new_role = CLIENTS["iam"].create_role(
+            RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document, Tags=tags
+          )
+        else:
+          new_role = CLIENTS["iam"].create_role(
+              RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document
+          )
       except ClientError as error:
         fail("Exception creating new role named: {} {}".format(role_name, sys.exc_info(), error))
       print(new_role["Role"]["RoleId"])
@@ -688,7 +693,7 @@ def main():
 
     # 1. CONDITIONALLY MAKE ROLE AND/OR INSTANCE PROFILE FOR THE SERVICE
     # If service gets a role, create with either a custom or default AssumeRole policy document
-    if (sr_entry['tags']):
+    if 'tags' in sr_entry.keys():
       conditionally_create_role(target_name, sr_entry, tags=sr_entry['tags'])
     else:
       conditionally_create_role(target_name, sr_entry)


### PR DESCRIPTION
# Ticket
OPS-15630 In order to allow session manager users to log with dev username on ec2, I need ef-generate to support tags when creating IAM roles

# Details
Added support for optional tags in ef-generate