### PR TITLE
Sort terms array in order to perform correct comparison

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -213,8 +213,11 @@ class NewRelicAlerts(object):
         local_alert_apm_condition['type'] = remote_alert_apm_condition['type']
         local_alert_apm_condition['entities'] = remote_alert_apm_condition['entities']
 
+        local_alert_apm_condition['terms'].sort(key=lambda x: x['priority'])
+        remote_alert_apm_condition['terms'].sort(key=lambda x: x['priority'])
+
         if local_alert_apm_condition != remote_alert_apm_condition:
-          logger.info("Local alert apm condition differs from remote alert apm condition for {}-{}. Updating remote.".format(policy.env,policy.service))
+          logger.info("Local alert apm condition differs from remote alert apm condition for {}-{}. Updating remote.".format(policy.env, policy.service))
           logger.debug("Local: {}\nRemote: {}".format(local_alert_apm_condition, remote_alert_apm_condition))
           self.newrelic.put_policy_alert_apm_condition(remote_alert_apm_condition["id"], local_alert_apm_condition)
 
@@ -284,7 +287,7 @@ class NewRelicAlerts(object):
             applications = self.newrelic.get_applications(application_name=policy.name)
 
             if not len(applications):
-              logger.info('No applications hosted for this policy. Skip creating any APM alert')
+              logger.info('No applications hosted for this policy: {}. Skip creating any APM alert'.format(policy.name))
               continue
 
             condition_value['entities'] = [applications[0]['id']]


### PR DESCRIPTION
# Ticket
N/A

# Details
Optimize NewRelic APM condition comparison as terms come in a different order from API and `ef_site_config.yml` has a specific order so comparing remote dictionary with the local one, the comparison is not consistent.

Sometimes, NewRelic API returns `terms` array with `warning` priority as first element, but this is not consistent.

Example:
```
-------------- ef_site_config.yml ------------
     instance_init_failure:
        name: instance_init_failure
        enabled: false
        value_function: sum
        violation_time_limit_seconds: 3600
        terms:
          - duration: "5"
            operator: above
            priority: critical
            threshold: "0"
            time_function: any
          - duration: "5"
            operator: above
            priority: warning       /// WARNING
            threshold: "0"
            time_function: any

------------- response from NewRelic REST API ---------
      instance_init_failure:
        name: instance_init_failure
        enabled: false
        value_function: sum
        violation_time_limit_seconds: 3600
        terms:
          - duration: "5"
            operator: above
            priority: warning         /// WARNING
            threshold: "1"
            time_function: any
          - duration: "5"
            operator: above
            priority: critical
            threshold: "0"
            time_function: any
```

# Testing
False positives comparison are not pushed as updates into NewRelic