### PR TITLE
Add flag for lbv1 style escapes in ciphertexts

### DIFF
--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -177,6 +177,7 @@ def handle_args_and_set_context(args):
   group.add_argument("--secret_file", help="json file containing secrets to be encrypted", default="")
   parser.add_argument("--match", help="used in conjunction with --secret_file to match against keys to be encrypted", default="")
   parser.add_argument("--length", help="length of generated password (default 32)", default=32)
+  parser.add_argument("--lbv1_escapes", help="if secret has escapes, encode them for lbv1 consumption", action="store_true", default=False)
   parsed_args = vars(parser.parse_args(args))
   context = EFPWContext()
 
@@ -189,8 +190,10 @@ def handle_args_and_set_context(args):
   context.decrypt = parsed_args["decrypt"]
   context.re_encrypt = parsed_args["re_encrypt"]
   context.length = parsed_args["length"]
-  # unescape any escapes that the shell might've added; e.g: \\n becomes \n
-  context.plaintext = parsed_args["plaintext"].decode("string_escape")
+  context.plaintext = parsed_args["plaintext"]
+  if not parsed_args["lbv1_escapes"]:
+    # unescape any escapes that the shell might've added; e.g: \\n becomes \n
+    context.plaintext = parsed_args["plaintext"].decode("string_escape")
   context.secret_file = parsed_args["secret_file"]
   context.match = parsed_args["match"]
   if context.match or context.secret_file:

--- a/tests/unit_tests/test_ef_password.py
+++ b/tests/unit_tests/test_ef_password.py
@@ -85,6 +85,20 @@ class TestEFPassword(unittest.TestCase):
     self.assertEqual(context.length, 10)
     self.assertEqual(context.plaintext, expected_plaintext)
 
+  def test_args_plaintext_lbv1_escape_sequences(self):
+    """
+    Test parsing args with all valid values and plaintext with latebindv1
+    compatible escape sequences When called from bash in this form
+    `ef-password --plaintext "hello\nworld" --lbv1_escapes` the OS transforms the plaintext
+    argument into `"hello\\nworld"`. The decrypted value should have the same form
+    """
+    expected_plaintext = "hello\\nworld"
+    args = [self.service, self.env, "--lbv1_escapes", "--plaintext", "hello\\nworld"]
+    context = ef_password.handle_args_and_set_context(args)
+    self.assertEqual(context.env, self.env)
+    self.assertEqual(context.service, self.service)
+    self.assertEqual(context.plaintext, expected_plaintext)
+
   def test_args_secret_file(self):
     """Test parsing args with all valid values (secret file)"""
     args = [self.service, self.env, "--length", "10", "--secret_file",


### PR DESCRIPTION
# Details
Adding a flag to enable encrypting escaped sequences for latebind v1.

https://github.com/crunchyroll/ef-open/releases/tag/1.25.0 switched the encryption escape method so that escaped sequences rendered as expected (e.g. `\n` renders as a newline) in latebindb2.

This means that encrypting for latebindv1 with escapes was no longer possible.
