### PR TITLE
Support AWS DynamoDB Stream ARN lookup

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -878,6 +878,23 @@ class EFAwsResolver(object):
     except ClientError:
       return default
 
+  def dynamodb_stream_arn(self, lookup, default=None):
+    """
+    Args:
+      lookup: the name of the DynamoDB table to look up
+      default: the optional value to return if lookup failed; returns None if not set
+    Returns:
+      The DynamoDB Stream ARN with a label matching 'lookup' or default/None if no match found
+    """
+    try:
+      dynamodb_table = EFAwsResolver.__CLIENTS["dynamodb"].describe_table(TableName=lookup)
+      if dynamodb_table:
+        return dynamodb_table["Table"]["LatestStreamArn"]
+      else:
+        return default
+    except ClientError:
+      return default
+
   def lookup(self, token):
     try:
       kv = token.split(",")
@@ -899,6 +916,8 @@ class EFAwsResolver(object):
       return self.cognito_idp_user_pool_arn(*kv[1:])
     elif kv[0] == "cognito-idp:user-pool-id":
       return self.cognito_idp_user_pool_id(*kv[1:])
+    elif kv[0] == "dynamodb:stream-arn":
+      return self.dynamodb_stream_arn(*kv[1:])
     elif kv[0] == "ec2:elasticip/elasticip-id":
       return self.ec2_elasticip_elasticip_id(*kv[1:])
     elif kv[0] == "ec2:elasticip/elasticip-ipaddress":

--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -234,6 +234,7 @@ class EFTemplateResolver(object):
       "cloudfront",
       "cognito-identity",
       "cognito-idp",
+      "dynamodb",
       "ec2",
       "ecr",
       "elbv2",


### PR DESCRIPTION
## Ready State
**Ready**

## Synopsis
Support AWS DynamoDB Stream ARN lookup

## Changelog
  * Added `dynamodb:stream-arn,...` lookup base on the DynamoDB Table name
  * Added unit-tests associated with this lookup
  * Sort some values in lexical order

## Testing
```
000939-ml:ef-open jwong$ pytest tests/
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 2.7.15, pytest-3.7.2, py-1.5.4, pluggy-0.7.1
rootdir: /Users/jwong/workspace/ef-open, inifile:
plugins: cov-2.5.1
collected 241 items

tests/unit_tests/test_ef_aws_resolver.py ...................................................................................................                                             [ 41%]
tests/unit_tests/test_ef_conf_utils.py ..........                                                                                                                                        [ 45%]
tests/unit_tests/test_ef_config.py .............                                                                                                                                         [ 50%]
tests/unit_tests/test_ef_config_resolver.py ....                                                                                                                                         [ 52%]
tests/unit_tests/test_ef_generate.py ...........                                                                                                                                         [ 56%]
tests/unit_tests/test_ef_instanceinit_config_reader.py ..                                                                                                                                [ 57%]
tests/unit_tests/test_ef_password.py ...............                                                                                                                                     [ 63%]
tests/unit_tests/test_ef_service_registry.py ........                                                                                                                                    [ 67%]
tests/unit_tests/test_ef_site_config.py ....                                                                                                                                             [ 68%]
tests/unit_tests/test_ef_template_resolver.py ...............                                                                                                                            [ 75%]
tests/unit_tests/test_ef_utils.py ...................................                                                                                                                    [ 89%]
tests/unit_tests/test_ef_version.py ........................                                                                                                                             [ 99%]
tests/unit_tests/test_ef_version_resolver.py .                                                                                                                                           [100%]

================================================================================== 241 passed in 5.93 seconds ==================================================================================
000939-ml:ef-open jwong$```