### PR TITLE
add missing setter for the context.only_for property

### DIFF
--- a/efopen/ef_context.py
+++ b/efopen/ef_context.py
@@ -196,6 +196,10 @@ class EFContext(object):
     """Specific service registry entry targeted as parameter passed to tool"""
     return self._only_for
 
+  @only_for.setter
+  def only_for(self, value):
+    self._only_for = value
+
   @property
   def verbose(self):
     """True if the tool should print extra info"""


### PR DESCRIPTION
# Details
Fixing bug related to this new ef-generate arg

# Before
```
± |master {10} ✓| → ef-generate global.codemobs --commit --only_for role-dev-codemobs
Traceback (most recent call last):
  File "/usr/local/bin/ef-generate", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/efopen/ef_generate.py", line 636, in main
    CONTEXT = handle_args_and_set_context(sys.argv[1:])
  File "/usr/local/lib/python2.7/site-packages/efopen/ef_generate.py", line 149, in handle_args_and_set_context
    context.only_for = parsed_args["only_for"]
AttributeError: can't set attribute
```

# After
```
/Users/dlutsch/.local/share/virtualenvs/ef-open-43I3Cg99/bin/python /Users/dlutsch/workspace/ef-open/efopen/ef_generate.py proto0 --commit --devel --only manga-ftp
Not refreshing repo because --devel was set or running on Jenkins
env: proto0
env_full: proto0
env_short: proto
aws account profile: ellationeng
aws account number: 366843697376
running ef-generate only for entry: manga-ftp
Create security group: proto0-manga-ftp-ec2 in vpc: vpc-proto0
...
```
