### PR TITLE
OPS-15147 get rid of precheck flag

### DIFF
--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -289,8 +289,6 @@ def handle_args_and_set_context(args):
                       type=int, default=100)
   parser.add_argument("--location", help="On --set, also mark the url location of the static build's version file to"
                       "support dist-hash precheck", default="")
-  if EFConfig.ALLOW_EF_VERSION_SKIP_PRECHECK:
-    parser.add_argument("--noprecheck", help="--set or --rollback without precheck", action="store_true", default=False)
   parser.add_argument("--sr", help="optional /path/to/service_registry_file.json", default=None)
   parser.add_argument("--stable", help="On --set, also mark the version 'stable'", action="store_true")
   parser.add_argument("--verbose", help="Print additional info", action="store_true", default=False)
@@ -311,8 +309,7 @@ def handle_args_and_set_context(args):
   context._get = parsed_args["get"]
   context._history = parsed_args["history"]
   context._key = parsed_args["key"]
-  if EFConfig.ALLOW_EF_VERSION_SKIP_PRECHECK:
-    context._noprecheck = parsed_args["noprecheck"]
+  context._noprecheck = True
   if not 1 <= parsed_args["limit"] <= 1000:
     fail("Error in --limit. Valid range: 1..1000")
   context._limit = parsed_args["limit"]
@@ -366,133 +363,6 @@ def validate_context(context):
          "in ef_config and validate service registry entry".format(service_type, context.key))
 
   return True
-
-
-def precheck_ami_id(context):
-  """
-  Is the AMI in service the same as the AMI marked current in the version records?
-  This tool won't update records unless the world state is coherent.
-  Args:
-    context: a populated EFVersionContext object
-  Returns:
-    True if ok to proceed
-  Raises:
-    RuntimeError if not ok to proceed
-  """
-  # get the current AMI
-  key = "{}/{}".format(context.env, context.service_name)
-  print_if_verbose("precheck_ami_id with key: {}".format(key))
-  current_ami = context.versionresolver.lookup("ami-id,{}".format(key))
-  print_if_verbose("ami found: {}".format(current_ami))
-
-  # If bootstrapping (this will be the first entry in the version history)
-  # then we can't check it vs. running version
-  if current_ami is None:
-    print_if_verbose("precheck passed without check because current AMI is None")
-    return True
-
-  # Otherwise perform a consistency check
-  # 1. get IDs of instances running the AMI - will find instances in all environments
-  instances_running_ami = context.aws_client("ec2").describe_instances(
-      Filters=[{
-          'Name': 'image-id',
-          'Values': [current_ami]
-      }]
-  )["Reservations"]
-  if instances_running_ami:
-    instances_running_ami = [resv["Instances"][0]["InstanceId"] for resv in instances_running_ami]
-  print_if_verbose("instances running ami {}:\n{}".format(current_ami, repr(instances_running_ami)))
-
-  # 2. Get IDs of instances running as <context.env>-<context.service_name>
-  env_service = "{}-{}".format(context.env, context.service_name)
-  instances_running_as_env_service = context.aws_client("ec2").describe_instances(
-      Filters=[{
-          'Name': 'iam-instance-profile.arn',
-          'Values': ["arn:aws:iam::*:instance-profile/{}-{}".format(context.env, context.service_name)]
-      }]
-  )["Reservations"]
-  if instances_running_as_env_service:
-    instances_running_as_env_service = \
-        [resv["Instances"][0]["InstanceId"] for resv in instances_running_as_env_service]
-  print_if_verbose("instances running as {}".format(env_service))
-  print_if_verbose(repr(instances_running_as_env_service))
-
-  # 3. Instances running as env-service should be a subset of instances running the AMI
-  for instance_id in instances_running_as_env_service:
-    if instance_id not in instances_running_ami:
-      raise RuntimeError("Instance: {} not running expected ami: {}".format(instance_id, current_ami))
-
-  # Check passed - all is well
-  return True
-
-
-def precheck_dist_hash(context):
-  """
-  Is the dist in service the same as the dist marked current in the version records?
-  This tool won't update records unless the world state is coherent.
-  Args:
-    context: a populated EFVersionContext object
-  Returns:
-    True if ok to proceed
-  Raises:
-    RuntimeError if not ok to proceed
-  """
-  # get the current dist-hash
-  key = "{}/{}/dist-hash".format(context.service_name, context.env)
-  print_if_verbose("precheck_dist_hash with key: {}".format(key))
-  try:
-    current_dist_hash = Version(context.aws_client("s3").get_object(
-        Bucket=EFConfig.S3_VERSION_BUCKET,
-        Key=key
-    ))
-    print_if_verbose("dist-hash found: {}".format(current_dist_hash.value))
-  except ClientError as error:
-    if error.response["Error"]["Code"] == "NoSuchKey":
-      # If bootstrapping (this will be the first entry in the version history)
-      # then we can't check it vs. current version, thus we cannot get the key
-      print_if_verbose("precheck passed without check because current dist-hash is None")
-      return True
-    else:
-      fail("Exception while prechecking dist_hash for {} {}: {}".format(context.service_name, context.env, error))
-
-  # Otherwise perform a consistency check
-  # 1. get dist version in service for environment
-  try:
-    response = urllib2.urlopen(current_dist_hash.location, None, 5)
-    if response.getcode() != 200:
-      raise IOError("Non-200 response " + str(response.getcode()) + " reading " + current_dist_hash.location)
-    dist_hash_in_service = response.read().strip()
-  except urllib2.URLError as error:
-    raise IOError("URLError in http_get_dist_version: " + repr(error))
-
-  # 2. dist version in service should be the same as "current" dist version
-  if dist_hash_in_service != current_dist_hash.value:
-    raise RuntimeError("{} dist-hash in service: {} but expected dist-hash: {}"
-                       .format(key, dist_hash_in_service, current_dist_hash.value))
-
-  # Check passed - all is well
-  return True
-
-
-def precheck(context):
-  """
-  calls a function named "precheck_<key>" where <key> is context_key with '-' changed to '_'
-  (e.g. "precheck_ami_id")
-  Checking function should return True if OK, or raise RuntimeError w/ message if not
-  Args:
-    context: a populated EFVersionContext object
-  Returns:
-    True if the precheck passed, or if there was no precheck function for context.key
-  Raises:
-    RuntimeError if precheck failed, with explanatory message
-  """
-  if context.noprecheck:
-    return True
-  func_name = "precheck_" + context.key.replace("-", "_")
-  if func_name in globals() and isfunction(globals()[func_name]):
-    return globals()[func_name](context)
-  else:
-    return True
 
 
 def _get_stable_versions(context):
@@ -682,12 +552,6 @@ def cmd_set(context):
     else:
       raise RuntimeError("{} version for {}/{} is '=latest' but can't look up because method not found: {}".format(
                          context.key, context.env, context.service_name, func_name))
-
-  # precheck to confirm coherent world state before attempting set - whatever that means for the current key type
-  try:
-    precheck(context)
-  except Exception as e:
-    fail("Precheck failed: {}".format(e))
 
   s3_key = "{}/{}/{}".format(context.service_name, context.env, context.key)
   s3_version_status = EFConfig.S3_VERSION_STATUS_STABLE if context.stable else EFConfig.S3_VERSION_STATUS_UNDEFINED

--- a/efopen/ef_version.py
+++ b/efopen/ef_version.py
@@ -289,6 +289,7 @@ def handle_args_and_set_context(args):
                       type=int, default=100)
   parser.add_argument("--location", help="On --set, also mark the url location of the static build's version file to"
                       "support dist-hash precheck", default="")
+  parser.add_argument("--noprecheck", help="Flag is deprecated but left behind to not break things", action="store_true")
   parser.add_argument("--sr", help="optional /path/to/service_registry_file.json", default=None)
   parser.add_argument("--stable", help="On --set, also mark the version 'stable'", action="store_true")
   parser.add_argument("--verbose", help="Print additional info", action="store_true", default=False)

--- a/tests/unit_tests/test_ef_version.py
+++ b/tests/unit_tests/test_ef_version.py
@@ -47,7 +47,6 @@ class TestEFVersion(unittest.TestCase):
     self.history = "text"
     self.key = "ami-id"
     self.location = "https://s3-us-west-2.amazonaws.com/ellation-cx-proto3-static/foo/dist-hash"
-    self.noprecheck = None
     self.parsed_env_full = "global"
     self.service = "test-instance"
     self.service_name = "test-instance"
@@ -162,65 +161,6 @@ class TestEFVersion(unittest.TestCase):
     self.assertEqual(context.history, self.history)
     self.assertEqual(context.service_name, self.service_name)
     self.assertEqual(context.service_registry.filespec, self.service_registry_file)
-
-  @patch('ef_version.isfunction')
-  def test_noprecheck(self, mock_isfunction):
-    """Test precheck resolves the correct precheck method"""
-    mock_isfunction.return_value = True
-    self.noprecheck = True
-    self.assertTrue(ef_version.precheck(self))
-    mock_isfunction.assert_not_called()
-
-  @patch('ef_version.isfunction')
-  @patch('ef_version.globals')
-  def test_precheck(self, mock_globals, mock_isfunction):
-    """Test precheck returns correct method"""
-    mock_isfunction.return_value = True
-    mock_precheck_method = Mock(name='mock precheck method')
-    mock_precheck_method.return_value = True
-    mock_globals.return_value = {"precheck_ami_id": mock_precheck_method}
-    self.assertTrue(ef_version.precheck(self))
-    mock_precheck_method.assert_called_once()
-
-  @patch('ef_version.Version')
-  @patch('urllib2.urlopen')
-  def test_precheck_dist_hash(self, mock_urlopen, mock_version_object):
-    """Test precheck of dist hash version"""
-    mock_version_object.return_value = self.mock_version
-    mock_s3_response = Mock(name='mock s3 response')
-    mock_s3_response.getcode.return_value = 200
-    mock_s3_response.read.return_value = self.value
-    mock_urlopen.return_value = mock_s3_response
-    self.assertTrue(ef_version.precheck_dist_hash(self))
-
-  @patch('ef_version.Version')
-  @patch('urllib2.urlopen')
-  def test_precheck_dist_hash_s3_404(self, mock_urlopen, mock_version_object):
-    """Test precheck to validate error thrown on a Non-200 response from s3"""
-    mock_version_object.return_value = self.mock_version
-    mock_s3_response = Mock(name='mock s3 response')
-    mock_s3_response.getcode.return_value = 404
-    mock_urlopen.return_value = mock_s3_response
-    with self.assertRaises(IOError):
-      ef_version.precheck_dist_hash(self)
-
-  @patch('ef_version.Version')
-  @patch('urllib2.urlopen')
-  def test_precheck_dist_hash_urllib_error(self, mock_urlopen, mock_version_object):
-    """Test preckek to validate error thrown on url error"""
-    mock_version_object.return_value = self.mock_version
-    mock_s3_response = Mock(name='mock s3 response')
-    mock_urlopen.return_value = mock_s3_response
-    mock_urlopen.side_effect = IOError
-    with self.assertRaises(IOError):
-      ef_version.precheck_dist_hash(self)
-
-  @patch('ef_version.Version')
-  def test_precheck_dist_hash_version_none(self, mock_version_object):
-    """Test precheck_dist_hash when current version is none"""
-    response = {"Error": {"Code": "NoSuchKey"}}
-    mock_version_object.side_effect = ClientError(response, "Get Object")
-    self.assertTrue(ef_version.precheck_dist_hash(self))
 
 
 class TestVersion(unittest.TestCase):


### PR DESCRIPTION
# Ticket
[OPS-15147](https://ellation.atlassian.net/browse/OPS-15147)

# Details
The purpose of getting rid of the flag is that we've seen cloudformation complete but old instances with the old ami-id are still active. When ef-version is run without the noprecheck, even though cloudformation says it's done, ef-version will error saying something went wrong, because the old instances are up. But those old instances will eventually self terminate.

The precheck flag causes more problems than it solves now.
I have to leave the flag in the command line but it won't do anything now. If I remove it now, the python binary complains about being supplied a flag that doesn't exist, and many of our jenkins jobs have that hard coded right now.

TESTS
<img width="1169" alt="Screen Shot 2020-10-15 at 4 43 54 PM" src="https://user-images.githubusercontent.com/29384306/96196994-a73d5600-0f05-11eb-98a0-78a5d86a26f7.png">
