### PR TITLE
OPS-16006 Add alert override to disable opsgenie for a service in service_registry.json

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -667,6 +667,10 @@ def main():
   print("aws account profile: {}".format(CONTEXT.account_alias))
   print("aws account number: {}".format(CONTEXT.account_id))
 
+  # If we're only ef-generate for a specific service, print it out here
+  if CONTEXT.only_for:
+    print("running ef-generate only for entry: {}".format(CONTEXT.only_for))
+
   # Step through all services in the service registry
   for CONTEXT.service in CONTEXT.service_registry.iter_services():
     service_name = CONTEXT.service[0]
@@ -678,8 +682,6 @@ def main():
     # Are we targeting a specific entry in the registry?
     if CONTEXT.only_for and CONTEXT.only_for != service_name:
       continue
-    else:
-      print("running ef-generate only for entry: {}".format(service_name))
 
     # Is this service_type handled by this tool?
     if service_type not in SUPPORTED_SERVICE_TYPES:

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -7,7 +7,7 @@ from ef_utils import kms_decrypt
 from newrelic_interface import NewRelic, AlertPolicy
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO, Force=True)
 logger = logging.getLogger(__name__)
 
 
@@ -87,8 +87,8 @@ class NewRelicAlerts(object):
     conditions_to_create = set(policy.config_conditions.keys()).difference(remote_conditions)
 
     for key in conditions_to_create:
-      self.newrelic.create_alert_condition(policy.config_conditions[key])
       logger.info("create condition {} for policy {}".format(key, policy.name))
+      self.newrelic.create_alert_condition(policy.config_conditions[key])
 
   def update_cloudfront_policy(self):
     # Update Cloudfront alert policies

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -240,6 +240,7 @@ class NewRelicAlerts(object):
     for service_name, service_config in self.context.service_registry.iter_services(service_group="application_services"):
       service_environments = service_config['environments']
       service_alert_overrides = service_config.get('alerts', {})
+      opsgenie_enabled = service_alert_overrides.get('opsgenie_enabled', True)
       opsgenie_team = service_config.get("team_opsgenie", "")
       service_type = service_config['type']
 
@@ -248,6 +249,8 @@ class NewRelicAlerts(object):
 
       if self.context.env in service_environments:
         policy = AlertPolicy(env=self.context.env, service=service_name)
+
+        logger.debug("Policy ID is {}".format(policy.id))
 
         # Create service alert policy if it doesn't already exist
         if not self.newrelic.alert_policy_exists(policy.name):
@@ -262,7 +265,8 @@ class NewRelicAlerts(object):
         # Configure Opsgenie notifications for services running in the production account
         try:
           prod_account = EFConfig.ENV_ACCOUNT_MAP['prod']
-          if self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]:
+          if (self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]
+              and opsgenie_enabled):
             self.add_policy_to_opsgenie_channel(policy, opsgenie_team)
         except KeyError:
           pass
@@ -302,6 +306,7 @@ class NewRelicAlerts(object):
     for service_name, service_config in chain(platform_services, application_services):
       service_environments = service_config['environments']
       service_alert_overrides = service_config.get('alerts', {})
+      opsgenie_enabled = service_alert_overrides.get('opsgenie_enabled', True)
       opsgenie_team = service_config.get("team_opsgenie", "")
       service_type = service_config['type']
 
@@ -310,6 +315,8 @@ class NewRelicAlerts(object):
 
       if self.context.env in service_environments:
         policy = AlertPolicy(env=self.context.env, service=service_name)
+
+        logger.debug("Policy ID is {}".format(policy.id))
 
         # Create service alert policy if it doesn't already exist
         if not self.newrelic.alert_policy_exists(policy.name):
@@ -324,7 +331,8 @@ class NewRelicAlerts(object):
         # Configure Opsgenie notifications for services running in the production account
         try:
           prod_account = EFConfig.ENV_ACCOUNT_MAP['prod']
-          if self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]:
+          if (self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]
+              and opsgenie_enabled):
             self.add_policy_to_opsgenie_channel(policy, opsgenie_team)
         except KeyError:
           pass

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -268,6 +268,8 @@ class NewRelicAlerts(object):
           if (self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]
               and opsgenie_enabled):
             self.add_policy_to_opsgenie_channel(policy, opsgenie_team)
+          elif not opsgenie_enabled:
+            logger.info("Not adding opsgenie_channel {} for service {} alert policy.".format(opsgenie_team, service_name))
         except KeyError:
           pass
 
@@ -334,6 +336,8 @@ class NewRelicAlerts(object):
           if (self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]
               and opsgenie_enabled):
             self.add_policy_to_opsgenie_channel(policy, opsgenie_team)
+          elif not opsgenie_enabled:
+            logger.info("Not adding opsgenie_channel {} for service {} alert policy.".format(opsgenie_team, service_name))
         except KeyError:
           pass
 

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -285,10 +285,10 @@ class NewRelicAlerts(object):
         try:
           prod_account = EFConfig.ENV_ACCOUNT_MAP['prod']
           if (self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]
-              and opsgenie_enabled):
+              and opsgenie_enabled and opsgenie_team):
             self.add_policy_to_opsgenie_channel(policy, opsgenie_team)
-          elif not opsgenie_enabled:
-            logger.info("Not adding opsgenie_channel {} for service {} alert policy.".format(opsgenie_team, service_name))
+          elif not opsgenie_enabled or not opsgenie_team:
+            logger.warning("Not adding opsgenie_channel {} for service {} alert policy.".format(opsgenie_team, service_name))
         except KeyError:
           pass
 
@@ -353,10 +353,10 @@ class NewRelicAlerts(object):
         try:
           prod_account = EFConfig.ENV_ACCOUNT_MAP['prod']
           if (self.context.env in ["prod", "global.{}".format(prod_account), "mgmt.{}".format(prod_account)]
-              and opsgenie_enabled):
+              and opsgenie_enabled and opsgenie_team):
             self.add_policy_to_opsgenie_channel(policy, opsgenie_team)
-          elif not opsgenie_enabled:
-            logger.info("Not adding opsgenie_channel {} for service {} alert policy.".format(opsgenie_team, service_name))
+          elif not opsgenie_enabled or not opsgenie_team:
+            logger.warning("Not adding opsgenie_channel {} for service {} alert policy.".format(opsgenie_team, service_name))
         except KeyError:
           pass
 


### PR DESCRIPTION
# Ticket
[OPS-16006](https://ellation.atlassian.net/browse/OPS-16006)

# Details
Currently ef-generate is failing in Ellation prod due to the following 3 services having an empty string in their team_opsgenie field: prod-cr-web.admin, prod-cr-web.cms, prod-cr-web.support.

The reason this field is empty is due to the explanation in this PR, crunchyroll/ellation_formation#7904

Because of this, ef-generate errors because it can't add an opsgenie_team of an invalid value, empty string.

To address this, we're implementing the ability for the team to add a alert overrride in the service registry, opsgenie_enabled, that can be set to false. What this does is make it so in the alert policies' notification, the opsgenie team will not be added.

I've looked into using this feature, New Relic muting to see if this would help instead, but currently there is no way to perpetually mute an alert during off hours forever. https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications
