### PR TITLE
OPS-16049 Use separate newrelic keys for REST API calls

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -47,9 +47,14 @@ class NewRelicAlerts(object):
 
   @property
   def admin_token(self):
+    admin_token = self.config.get('admin_token', "")
     admin_token_map = self.config.get('admin_token_map', "")
-    aws_account_alias = get_account_alias(self.context.env)
-    plain_token = admin_token_map.get(aws_account_alias)
+
+    if admin_token:
+      plain_token = admin_token
+    else:
+      aws_account_alias = get_account_alias(self.context.env)
+      plain_token = admin_token_map.get(aws_account_alias)
 
     if plain_token is None:
       raise KeyError("NewRelic Admin Token not defined for {}".format(aws_account_alias))

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -52,7 +52,7 @@ class NewRelicAlerts(object):
     plain_token = admin_token_map.get(aws_account_alias)
 
     if plain_token is None:
-      raise KeyError("NewRelic Admin Token not defined for {}".format(aws_acaws_account_aliascount))
+      raise KeyError("NewRelic Admin Token not defined for {}".format(aws_account_alias))
 
     if self.config['token_kms_encrypted']:
       return kms_decrypt(self.clients['kms'], plain_token).plaintext


### PR DESCRIPTION
# Ticket
[OPS-16049](https://ellation.atlassian.net/browse/OPS-16049)

# Details
Adjust ef-open to communicate with NewRelic API with REST keys associated to specific AWS environments

# Testing
Ran a simple ef-generate for specific envs and it used correct values specified in `ef_site_config.yml` 