### PR TITLE
OPS-16054-Disallow_some_characters_in_ef-password

### DIFF
--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding: utf-8
 
 from __future__ import print_function
 from collections import OrderedDict
@@ -23,7 +24,7 @@ class EFPWContext(EFContext):
     self._secret_file = None
     self._match = None
     self._special_character_override = None
-    self.forbidden_characters = ['§', '±', '\\', '>', '<', ':', '\'', '"', '`']
+    self._forbidden_characters = ['§', '±', '\\', '>', '<', ':', '\'', '"', '`']
 
   @property
   def decrypt(self):
@@ -187,7 +188,7 @@ def handle_args_and_set_context(args):
   parser = argparse.ArgumentParser(description="Encrypt/decrypt template secrets.")
   parser.add_argument("service", help="name of service password is being generated for")
   parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
-  parser.add_argument("special_character_override", help="comma-separated list of characters \
+  parser.add_argument("--special_character_override", help="comma-separated list of characters \
     to override - only use with plaintext argument to allow a special charater set.\
     Pick a subset from: §,±,<,>,',\",`,\\,: which are denied by default" , default="")
   group = parser.add_mutually_exclusive_group()
@@ -225,8 +226,9 @@ def handle_args_and_set_context(args):
     parser.error("special_character_override parameter can only be specified when plaintext parameter is specified")
   if context.special_character_override:
     for special_char in context.special_character_override.split(","):
+      special_char = special_char.strip()
       if special_char not in context.forbidden_characters:
-        parser.error("{} special character is part of forbidden characters list: {}".format(special_char, ', '.join(forbidden_characters)))
+        parser.error("{} special character is part of forbidden characters list: {}".format(special_char, ', '.join(context.forbidden_characters)))
   return context
 
 

--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -189,7 +189,7 @@ def handle_args_and_set_context(args):
   parser.add_argument("service", help="name of service password is being generated for")
   parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
   parser.add_argument("--special_character_override", help="comma-separated list of characters \
-    to override in double quotes - only use with plaintext argument to allow a special charater set.\
+    to override in quotes - only use with plaintext argument to allow a special charater set.\
     Pick a subset from: §,±,<,>,',\",`,\\,: which are denied by default" , default="")
   group = parser.add_mutually_exclusive_group()
   group.add_argument("--decrypt", help="encrypted string to be decrypted", default="")

--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -189,7 +189,7 @@ def handle_args_and_set_context(args):
   parser.add_argument("service", help="name of service password is being generated for")
   parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
   parser.add_argument("--special_character_override", help="comma-separated list of characters \
-    to override - only use with plaintext argument to allow a special charater set.\
+    to override in double quotes - only use with plaintext argument to allow a special charater set.\
     Pick a subset from: §,±,<,>,',\",`,\\,: which are denied by default" , default="")
   group = parser.add_mutually_exclusive_group()
   group.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
@@ -222,7 +222,7 @@ def handle_args_and_set_context(args):
       raise ValueError("Must have both --match and --secret_file flag")
   context.special_character_override = parsed_args["special_character_override"]
   #special_characters_override only applies when plaintext is present
-  if context.plaintext is None and context.special_character_override:
+  if (context.plaintext is None or context.plaintext == '') and context.special_character_override:
     parser.error("special_character_override parameter can only be specified when plaintext parameter is specified")
   if context.special_character_override:
     for special_char in context.special_character_override.split(","):

--- a/efopen/ef_password.py
+++ b/efopen/ef_password.py
@@ -187,7 +187,9 @@ def handle_args_and_set_context(args):
   parser = argparse.ArgumentParser(description="Encrypt/decrypt template secrets.")
   parser.add_argument("service", help="name of service password is being generated for")
   parser.add_argument("env", help=", ".join(EFConfig.ENV_LIST))
-  parser.add_argument("special_character_override", help="comma-separated list of characters to override - only use with plaintext argument to allow a special charater set. Pick a subset from: §,±,<,>,',\",`,\\,: which are denied by default" , default="")
+  parser.add_argument("special_character_override", help="comma-separated list of characters \
+    to override - only use with plaintext argument to allow a special charater set.\
+    Pick a subset from: §,±,<,>,',\",`,\\,: which are denied by default" , default="")
   group = parser.add_mutually_exclusive_group()
   group.add_argument("--decrypt", help="encrypted string to be decrypted", default="")
   group.add_argument("--re-encrypt", help="encrypted string to be re encrypted for a new service", default="")
@@ -264,7 +266,7 @@ def main():
     for forbidden_char in context.forbidden_characters:
       if forbidden_char in password and forbidden_char not in context.special_character_override:
         raise ValueError(
-            "The chosen password contains illegal character {}. If you want to override this behavior, please use the argument --special_character_override".format(forbidden_char))
+            "Character {} is forbidden. Use the argument --special_character_override to bypass it.".format(forbidden_char))
   else:
     password = generate_secret(context.length)
     print("Generated Secret: {}".format(password))


### PR DESCRIPTION
# Ticket
[OPS-16054](https://ellation.atlassian.net/browse/OPS-16054)

# Details
- ef-password should do a check on the plaintext value of a secret before encrypting it and ensure that certain special characters are not present. If they are, ef-password should return an error.
- A user can override this behavior by passing in a flag. something like `--special-character-override` or some such.