### PR TITLE
OPS-16150 Output errors for why calls to new relic fails

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -266,6 +266,8 @@ class NewRelicAlerts(object):
       if service_type not in ['aws_ec2', 'aws_ecs', 'aws_ecs_http', 'http_service']:
         continue
 
+      logger.info("Service: {}".format(service_name))
+
       if self.context.env in service_environments:
         policy = AlertPolicy(env=self.context.env, service=service_name)
 
@@ -333,6 +335,8 @@ class NewRelicAlerts(object):
 
       if service_type != 'aws_lambda':
         continue
+
+      logger.info("Service: {}".format(service_name))
 
       if self.context.env in service_environments:
         policy = AlertPolicy(env=self.context.env, service=service_name)

--- a/efopen/newrelic_interface.py
+++ b/efopen/newrelic_interface.py
@@ -308,3 +308,6 @@ class NewRelic(object):
       response_key='channels'
     )
     return self.all_notification_channels
+
+  def _log_request_errors(self, request):
+    pass

--- a/efopen/newrelic_interface.py
+++ b/efopen/newrelic_interface.py
@@ -165,6 +165,11 @@ class NewRelic(object):
       headers=self.auth_header,
       data=json.dumps({"data": condition})
     )
+
+    if not add_condition.ok:
+      logger.error("Alert condition {} got a non 200 response code {} for the following reason: {}".format(
+        condition, add_condition.status_code, add_condition.text))
+
     add_condition.raise_for_status()
     return
 
@@ -189,6 +194,11 @@ class NewRelic(object):
       headers=self.auth_header,
       data=json.dumps({"nrql_condition": condition})
     )
+
+    if not add_condition.ok:
+      logger.error("Policy ID {} with condition {} got a non 200 response code {} for the following reason: {}".format(
+        policy_id, condition, add_condition.status_code, add_condition.text))
+
     add_condition.raise_for_status()
     return
 
@@ -205,6 +215,11 @@ class NewRelic(object):
       headers=self.auth_header,
       data=json.dumps({"nrql_condition": condition})
     )
+
+    if not put_condition.ok:
+      logger.error("Condition ID {} with condition {} got a non 200 response code {} for the following reason: {}".format(
+        condition_id, condition, put_condition.status_code, put_condition.text))
+
     put_condition.raise_for_status()
     return
 
@@ -215,6 +230,11 @@ class NewRelic(object):
       headers=self.auth_header,
       data=json.dumps({"condition": condition})
     )
+
+    if not add_condition.ok:
+      logger.error("Policy ID {} with condition {} got a non 200 response code {} for the following reason: {}".format(
+        policy_id, condition, add_condition.status_code, add_condition.text))
+
     add_condition.raise_for_status()
     return
 
@@ -231,6 +251,11 @@ class NewRelic(object):
       headers=self.auth_header,
       data=json.dumps({"condition": condition})
     )
+
+    if not put_condition.ok:
+      logger.error("Condition ID {} with condition {} got a non 200 response code {} for the following reason: {}".format(
+        condition_id, condition, put_condition.status_code, put_condition.text))
+
     put_condition.raise_for_status()
     return
 

--- a/efopen/newrelic_interface.py
+++ b/efopen/newrelic_interface.py
@@ -305,7 +305,7 @@ class NewRelic(object):
     """
     If the request does not have a 2XX status response, output the errors
     Args:
-      request: request object
+      response: response object
     """
     if not response.ok:
       logger.error("Request {} failed for the following reason {}".format(response.url, response.text))


### PR DESCRIPTION
# Ticket
[OPS-16150](https://ellation.atlassian.net/browse/OPS-16150)

# Details
Add better logging to ef-generate when errors to calls for creates or puts to new relic occurs.

Currently the requests.raise_for_status is useless in telling the reasons why it failed and just causes the program to error out.