### PR TITLE
OPS-16150 fix equality check for nrql alert conditions

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -224,15 +224,13 @@ class NewRelicAlerts(object):
   def update_alert_nrql_condition_if_different(self, local_alert_nrql_condition, policy):
     for remote_alert_nrql_condition in policy.remote_alert_nrql_conditions:
       if remote_alert_nrql_condition["name"] == local_alert_nrql_condition["name"]:
-        # Add fields that exist in the remote alert condition object but not in the local alert condition object.
-        # This is done so that we can test equality.
-        local_alert_nrql_condition['id'] = remote_alert_nrql_condition['id']
-        local_alert_nrql_condition['type'] = remote_alert_nrql_condition['type']
-
-        if local_alert_nrql_condition != remote_alert_nrql_condition:
-          logger.info("Local alert nrql condition differs from remote alert nrql condition for {}-{}. Updating remote.".format(policy.env,policy.service))
-          logger.debug("Local: {}\nRemote: {}".format(local_alert_nrql_condition, remote_alert_nrql_condition))
-          self.newrelic.put_policy_alert_nrql_condition(remote_alert_nrql_condition["id"], local_alert_nrql_condition)
+        relevant_fields = ["nrql", "terms", "enabled", "value_function", "violation_time_limit_seconds"]
+        for key in relevant_fields:
+          if local_alert_nrql_condition[key] != remote_alert_nrql_condition[key]:
+            logger.info("Local alert nrql condition differs from remote alert nrql condition for {}-{}. Updating remote.".format(policy.env, policy.service))
+            logger.info("Local: {}\nRemote: {}".format(local_alert_nrql_condition, remote_alert_nrql_condition))
+            self.newrelic.put_policy_alert_nrql_condition(remote_alert_nrql_condition["id"], local_alert_nrql_condition)
+            break
 
   def update_alert_apm_condition_if_different(self, local_alert_apm_condition, policy):
     for remote_alert_apm_condition in policy.remote_alert_apm_conditions:


### PR DESCRIPTION
# Ticket
[OPS-16150](https://ellation.atlassian.net/browse/OPS-16150)

# Details
The newrelic response object contains fields that don't exist in our request object. Rather than evaluating equality between these two objects, instead evaluating only the fields we actually care about. 
