### PR TITLE
OPS-16324 Fix error in logic that is causing a key lookup in dict to fail with ef-generate

### DIFF
--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -94,8 +94,8 @@ class NewRelicAlerts(object):
           if k in condition and condition[k] != v:
             self.newrelic.delete_policy_alert_condition(condition['id'])
             policy.remote_conditions = self.newrelic.get_policy_alert_conditions(policy.id)
-            logger.info("delete condition {} from policy {}. ".format(condition['name'], policy.name) +
-                        "current value differs from config")
+            logger.info("delete condition {} with value {} from policy {}. ".format(condition['name'], condition[k], policy.name) +
+                        "due to different current local config value {}".format(v))
             break
 
     return policy

--- a/efopen/newrelic_executor.py
+++ b/efopen/newrelic_executor.py
@@ -91,7 +91,7 @@ class NewRelicAlerts(object):
       if condition['name'] in policy.config_conditions:
         config_condition = policy.config_conditions[condition['name']]
         for k, v in config_condition.items():
-          if condition[k] != v:
+          if k in condition and condition[k] != v:
             self.newrelic.delete_policy_alert_condition(condition['id'])
             policy.remote_conditions = self.newrelic.get_policy_alert_conditions(policy.id)
             logger.info("delete condition {} from policy {}. ".format(condition['name'], policy.name) +
@@ -310,7 +310,8 @@ class NewRelicAlerts(object):
         # NRQL alert conditions
         remote_alert_nrql_condition_names = [remote_alert_nrql_condition['name'] for remote_alert_nrql_condition in policy.remote_alert_nrql_conditions]
         for condition_name, condition_value in policy.local_alert_nrql_conditions.items():
-          if condition_name not in remote_alert_nrql_condition_names:
+          if unicode(condition_name, "utf-8") not in remote_alert_nrql_condition_names:
+            logger.info("Creating alert nrql condition {} for service {}".format(condition_name, service_name))
             self.newrelic.create_alert_nrql_condition(policy.id, condition_value)
           else:
             self.update_alert_nrql_condition_if_different(condition_value, policy)
@@ -319,7 +320,7 @@ class NewRelicAlerts(object):
         policy = self.override_alert_apm_condition_values(policy, service_alert_overrides)
         remote_alert_apm_condition_names = [remote_alert_apm_condition['name'] for remote_alert_apm_condition in policy.remote_alert_apm_conditions]
         for condition_name, condition_value in policy.local_alert_apm_conditions.items():
-          if condition_name not in remote_alert_apm_condition_names:
+          if unicode(condition_name, "utf-8") not in remote_alert_apm_condition_names:
             applications = self.newrelic.get_applications(application_name=policy.name)
 
             if not len(applications):
@@ -327,6 +328,7 @@ class NewRelicAlerts(object):
               continue
 
             condition_value['entities'] = [applications[0]['id']]
+            logger.info("Creating alert apm condition {} for service {}".format(condition_name, service_name))
             self.newrelic.create_alert_apm_condition(policy.id, condition_value)
           else:
             self.update_alert_apm_condition_if_different(condition_value, policy)


### PR DESCRIPTION
# Ticket
[OPS-16324](https://ellation.atlassian.net/browse/OPS-16324)

# Details
This PR addresses the error ef-generate is running into:
`20:13:13 > Creating NewRelic Alerts
20:13:13 Traceback (most recent call last):
20:13:13   File "/bin/ef-generate", line 13, in <module>
20:13:13     sys.exit(main())
20:13:13   File "/var/lib/jenkins/.local/lib/python2.7/site-packages/efopen/ef_generate.py", line 728, in main
20:13:13     create_newrelic_alerts()
20:13:13   File "/var/lib/jenkins/.local/lib/python2.7/site-packages/efopen/ef_generate.py", line 631, in create_newrelic_alerts
20:13:13     NewRelicAlerts(CONTEXT, CLIENTS).run()
20:13:13   File "/var/lib/jenkins/.local/lib/python2.7/site-packages/efopen/newrelic_executor.py", line 375, in run
20:13:13     self.update_application_services_policies()
20:13:13   File "/var/lib/jenkins/.local/lib/python2.7/site-packages/efopen/newrelic_executor.py", line 302, in update_application_services_policies
20:13:13     policy = self.delete_conditions_not_matching_config_values(policy)
20:13:13   File "/var/lib/jenkins/.local/lib/python2.7/site-packages/efopen/newrelic_executor.py", line 94, in delete_conditions_not_matching_config_values
20:13:13     if condition[k] != v:
20:13:13 KeyError: 'filter'
20:13:13 Build step 'Execute shell' marked build as failure`

In addition, give better logging on old and new values when updates occur.

Fixed issue where checking if a python string is inside an array of unicode strings doesn't result in a true because the formatting is different. Have to convert the python string to unicode for it to evaluate correctly.