### PR TITLE
Update the PR template ticket section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 # Ticket
-[OPS-XXXXX](https://ellation.atlassian.net/browse/OPS-XXXXX)
+OPS-XXXXX
 
 # Details
 > A description of the motivation and implementation of this PR.


### PR DESCRIPTION
# Ticket
N/A

# Details
Since we have auto-link references, there's no point in having potentially obsolescent and wrong links in the PR template.

e.g OPS-123 vs [OPS-123](https://ellation.atlassian.net/browse/OPS-321)