### PR TITLE
update boto3 version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'efopen'
     ],
     install_requires=[
-        'boto3',
+        'boto3>=1.17.112',
         'click<=7.1.2',
         'PyYAML<=5.4.1',
         'cfn-lint',


### PR DESCRIPTION
recent updates to ef-version require an updated version of the boto3 library. works with the current version 1.17.112

