### PR TITLE
OPS-17701 add blackhole target group creation

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -478,6 +478,22 @@ class EFAwsResolver(object):
     except ClientError:
       return default
 
+  def elbv2_target_group_arn(self, lookup, default=None):
+    """
+    Args:
+      lookup: the friendly name of the v2 elb target group
+      default: value to return in case of no match
+    Returns:
+      The full ARN of the target group matching the lookup
+    """
+    try:
+      client = EFAwsResolver.__CLIENTS['elbv2']
+      elbs = client.describe_target_groups(Names=[lookup])
+      elb = elbs['TargetGroups'][0]
+      return elb['TargetGroupArn']
+    except ClientError:
+      return default
+
   def elbv2_target_group_arn_suffix(self, lookup, default=None):
     """
     Args:
@@ -985,6 +1001,8 @@ class EFAwsResolver(object):
       return self.elbv2_load_balancer_hosted_zone(*kv[1:])
     elif kv[0] == "elbv2:load-balancer/arn-suffix":
       return self.elbv2_load_balancer_arn_suffix(*kv[1:])
+    elif kv[0] == "elbv2:target-group/arn":
+      return self.elbv2_target_group_arn(*kv[1:])
     elif kv[0] == "elbv2:target-group/arn-suffix":
       return self.elbv2_target_group_arn_suffix(*kv[1:])
     elif kv[0] == "kms:decrypt":

--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -620,6 +620,33 @@ def conditionally_create_kms_key(role_name, service_type):
       fail("Error in enabling key rotation: {} {}".format(role_name, error))
 
 
+def conditionally_create_blackhole_target_groups(env, target_name, service_type):
+  if service_type != "http_service":
+    print_if_verbose("skipping black hole target group creation, {} is not an http_service".format(target_name))
+    return
+
+  vpc_name = "vpc-{}".format(env)
+  vpc_id = AWS_RESOLVER.ec2_vpc_vpc_id(vpc_name)
+
+  if CONTEXT.commit:
+    print_if_verbose("Creating {} blackhole target groups".format(target_name))
+    try:
+      CLIENTS["elbv2"].create_target_group(
+        Name="{}-i-blackhole".format(target_name),
+        Protocol='HTTP',
+        Port=8000,
+        VpcId=vpc_id
+      )
+      CLIENTS["elbv2"].create_target_group(
+        Name="{}-e-blackhole".format(target_name),
+        Protocol='HTTP',
+        Port=8000,
+        VpcId=vpc_id
+      )
+    except ClientError as error:
+      fail("Error creating {} blackhole target groups".format(target_name))
+
+
 def create_newrelic_alerts():
   """
    Create Newrelic Alerts for each entry in the service registry application_services
@@ -646,11 +673,11 @@ def main():
   try:
     # If running in EC2, always use instance credentials. One day we'll have "lambda" in there too, so use "in" w/ list
     if CONTEXT.whereami == "ec2":
-      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, None, "cloudfront", "ec2", "iam", "kms")
+      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, None, "cloudfront", "ec2", "elbv2", "iam", "kms")
       CONTEXT.account_id = str(json.loads(http_get_metadata('iam/info'))["InstanceProfileArn"].split(":")[4])
     else:
       # Otherwise, we use local user creds based on the account alias
-      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, CONTEXT.account_alias, "cloudfront", "ec2", "iam", "kms", "sts")
+      CLIENTS = create_aws_clients(EFConfig.DEFAULT_REGION, CONTEXT.account_alias, "cloudfront", "ec2", "elbv2", "iam", "kms", "sts")
       CONTEXT.account_id = get_account_id(CLIENTS["sts"])
   except RuntimeError:
     fail("Exception creating AWS clients in region {} with profile {}".format(
@@ -703,8 +730,8 @@ def main():
     if CONTEXT.env != "global":
       conditionally_create_profile(target_name, service_type)
 
-      # 2. SECURITY GROUP(S) FOR THE SERVICE : only some types of services get security groups
-      conditionally_create_security_groups(CONTEXT.env, service_name, service_type)
+    # 2. SECURITY GROUP(S) FOR THE SERVICE : only some types of services get security groups
+    conditionally_create_security_groups(CONTEXT.env, service_name, service_type)
 
     # 3. KMS KEY FOR THE SERVICE : only some types of services get kms keys
     conditionally_create_kms_key(target_name, service_type)
@@ -718,6 +745,9 @@ def main():
     # 6. INLINE SERVICE'S POLICIES INTO ROLE
     # only eligible service types with "policies" sections in the service registry get policies
     conditionally_inline_policies(target_name, sr_entry)
+
+    # 7. CREATE BLACKHOLE TARGET GROUPS FOR SERVICES WITH A LOAD BALANCER
+    conditionally_create_blackhole_target_groups(CONTEXT.env, target_name, service_type)
 
     # Break from the loop if we've finished working on the targeted entry
     if CONTEXT.only_for:


### PR DESCRIPTION
# Ticket
OPS-17701

# Details
Update ef-generate to create internal and external blackhole target groups for all http_service's

Choosing to do this in all environments rather than prod only for the following reasons:
1. Parity between prod & non-prod
2. Removes the need to create conditionals in the service cloudformation template around attached target groups
2. Target groups are free, why not?

## Updates

- Shortend "blackhole" to "bh" due to 32 character limit for target groups. 
- Checking for a new "short_name" field in the service registry entry due to the above mentioned limit
- Set blackhole target group port to 8080 so there there is never any confusion about putting actual service instances in there

# Testing
```
± |blackhole {20} ✓| → python2 ../ef-open/efopen/ef_generate.py proto0 --devel --commit --only_for test-instance.subservice
Not refreshing repo because --devel was set or running on Jenkins
env: proto0
env_full: proto0
env_short: proto
aws account profile: ellationeng
aws account number: 366843697376
running ef-generate only for entry: test-instance.subservice
> Creating NewRelic Alerts
Exit: success
```

# Related
See also: https://github.com/crunchyroll/ellation_formation/pull/9697