### PR TITLE
OPSOC-981 Fix indentation so SGs are being created

### DIFF
--- a/efopen/ef_generate.py
+++ b/efopen/ef_generate.py
@@ -752,8 +752,8 @@ def main():
     if CONTEXT.env != "global":
       conditionally_create_profile(target_name, service_type)
 
-    # 2. SECURITY GROUP(S) FOR THE SERVICE : only some types of services get security groups
-    conditionally_create_security_groups(CONTEXT.env, service_name, service_type)
+      # 2. SECURITY GROUP(S) FOR THE SERVICE : only some types of services get security groups
+      conditionally_create_security_groups(CONTEXT.env, service_name, service_type)
 
     # 3. KMS KEY FOR THE SERVICE : only some types of services get kms keys
     conditionally_create_kms_key(target_name, service_type)


### PR DESCRIPTION
# Ticket
OPSOC-981

## Ready State
**Ready**

## Synopsis
Fix indentation so SGs are being created in non-global environments only.

## Changelog
- partially revert the changes made in https://github.com/crunchyroll/ef-open/pull/230/files#diff-1e70b214a287c01c35da1669f3cecc2616e6f7e0bb7d90a619996ffaadf2dde0R755-R756, after that `ef-generate` should create security groups conditionally in non-global environments only.

## Before:
https://jenkins-build.ellationeng.cx-mgmt.com/job/ef-generate/7567/console
```
21:18:28 Error: could not get VPC by name: vpc-global
21:18:28 Not refreshing repo because --devel was set or running on Jenkins
21:18:28 env: global
21:18:28 env_full: global.ellationeng
21:18:28 env_short: global
21:18:28 aws account profile: ellationeng
21:18:28 aws account number: 366843697376
21:18:28 Create security group: global-lambda-health-jira-connector-lambda in vpc: vpc-global
```