### PR TITLE
OPS-17854 update wafv2 lookup output from id to arn

### DIFF
--- a/efopen/ef_aws_resolver.py
+++ b/efopen/ef_aws_resolver.py
@@ -573,13 +573,14 @@ class EFAwsResolver(object):
       else:
         return default
 
-  def wafv2_ip_set_id(self, lookup, default=None):
+  def wafv2_global_ip_set_arn(self, lookup, default=None):
     """
     Args:
       lookup: the friendly name of a Waf v2 IP set
       default: the optional value to return if lookup failed; returns None if not set
     Returns:
-      the ID of the IP set whose name matches 'lookup' or default/None if no match found
+      the ARN of the WAFv2 Global (Cloudfront) IP set whose name matches 'lookup' or default/None if no match found
+      note that global ARNs are always in us-east-1, which is why the region is hardcoded below
     """
     # list_rules returns at most 100 rules per request
     list_limit = 100
@@ -588,19 +589,20 @@ class EFAwsResolver(object):
     while True:
       for set in ip_sets["IPSets"]:
         if set["Name"] == lookup:
-          return set["Id"]
+          return "arn:aws:wafv2:us-east-1:{{{{ACCOUNT}}}}:global/ipset/{}/{}".format(lookup, set["Id"])
       if "NextMarker" in ip_sets:
         ip_sets = list_ip_sets(Limit=list_limit, Scope="CLOUDFRONT", NextMarker=ip_sets["NextMarker"])
       else:
         return default
 
-  def wafv2_rule_group_id(self, lookup, default=None):
+  def wafv2_global_rule_group_arn(self, lookup, default=None):
     """
     Args:
       lookup: the friendly name of a Waf v2 rule group
       default: the optional value to return if lookup failed; returns None if not set
     Returns:
-      the ID of the WAF v2 rule group whose name matches 'lookup' or default/None if no match found
+      the ARN of the WAFv2 Global (Cloudfront) Rule Group whose name matches 'lookup' or default/None if no match found
+      note that global ARNs are always in us-east-1, which is why the region is hardcoded below
     """
     # list_rules returns at most 100 rules per request
     list_limit = 100
@@ -608,20 +610,21 @@ class EFAwsResolver(object):
     while True:
       for group in rule_groups["RuleGroups"]:
         if group["Name"] == lookup:
-          return group["Id"]
+          return "arn:aws:wafv2:us-east-1:{{{{ACCOUNT}}}}:global/rulegroup/{}/{}".format(lookup, group["Id"])
       if "NextMarker" in rule_groups:
         rule_groups = EFAwsResolver.__CLIENTS["wafv2"].list_rule_groups(
           Limit=list_limit, Scope="CLOUDFRONT", NextMarker=rule_groups["NextMarker"])
       else:
         return default
 
-  def wafv2_web_acl_id(self, lookup, default=None):
+  def wafv2_global_web_acl_arn(self, lookup, default=None):
     """
     Args:
       lookup: the friendly name of a Waf v2 ACL
       default: the optional value to return if lookup failed; returns None if not set
     Returns:
-      the ID of the WAF v2 Web ACL whose name matches rule_name or default/None if no match found
+      the ARN of the WAFv2 Global (Cloudfront) Web ACL whose name matches rule_name or default/None if no match found
+      note that global ARNs are always in us-east-1, which is why the region is hardcoded below
     """
     # list_rules returns at most 100 rules per request
     list_limit = 100
@@ -629,7 +632,7 @@ class EFAwsResolver(object):
     while True:
       for acl in acls["WebACLs"]:
         if acl["Name"] == lookup:
-          return acl["Id"]
+          return "arn:aws:wafv2:us-east-1:{{{{ACCOUNT}}}}:global/webacl/{}/{}".format(lookup, acl["Id"])
       if "NextMarker" in acls:
         acls = EFAwsResolver.__CLIENTS["wafv2"].list_web_acls(
           Limit=list_limit, Scope="CLOUDFRONT", NextMarker=acls["NextMarker"])
@@ -1086,12 +1089,12 @@ class EFAwsResolver(object):
       return self.waf_rule_id(*kv[1:])
     elif kv[0] == "waf:web-acl-id":
       return self.waf_web_acl_id(*kv[1:])
-    elif kv[0] == "wafv2:ip-set-id":
-      return self.wafv2_ip_set_id(*kv[1:])
-    elif kv[0] == "wafv2:rule-group-id":
-      return self.wafv2_rule_group_id(*kv[1:])
-    elif kv[0] == "wafv2:web-acl-id":
-      return self.wafv2_web_acl_id(*kv[1:])
+    elif kv[0] == "wafv2:global/ip-set-arn":
+      return self.wafv2_global_ip_set_arn(*kv[1:])
+    elif kv[0] == "wafv2:global/rule-group-arn":
+      return self.wafv2_global_rule_group_arn(*kv[1:])
+    elif kv[0] == "wafv2:global/web-acl-arn":
+      return self.wafv2_global_web_acl_arn(*kv[1:])
     else:
       return None
       # raise("No lookup function for: "+kv[0])


### PR DESCRIPTION
# Ticket
OPS-17854

# Details
Change the return output of the recently added wafv2 lookups from the ID to the resource ARN. It seems that with WAFv2 the full ARN is needed for references, rather than just the ID like with WAFv1. 

# Local Testing
Test cloudformation template
```
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "test-wafv2-lookups",
  "Parameters": {
    "RuleGroup": {
      "Type": "String",
      "Default": "{{aws:wafv2:global/rule-group-arn,global-OfficeViaCloudflare}}"
    },
    "IpSet": {
      "Type": "String",
      "Default": "{{aws:wafv2:global/ip-set-arn,global-OfficeCidr}}"
    },
    "WebAcl": {
      "Type": "String",
      "Default": "{{aws:wafv2:global/web-acl-arn,proto0-CrApiAcl-v2}}"
    }
  }
}
```
ef-cf output
```
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "test-wafv2-lookups",
  "Parameters": {
    "RuleGroup": {
      "Type": "String",
      "Default": "arn:aws:wafv2:us-east-1:366843697376:global/rulegroup/global-OfficeViaCloudflare/4a01d770-2962-4dde-a959-a83e7c3bea30"
    },
    "IpSet": {
      "Type": "String",
      "Default": "arn:aws:wafv2:us-east-1:366843697376:global/ipset/global-OfficeCidr/f7324bf7-b814-4b21-8be6-7fb2375a4c52"
    },
    "WebAcl": {
      "Type": "String",
      "Default": "arn:aws:wafv2:us-east-1:366843697376:global/webacl/proto0-CrApiAcl-v2/26991be0-1e61-428a-81c5-5f1c8e554d78"
    }
  }
}
```
