### PR TITLE
OPS-17910 Prevent cache clients from being "poisoned"

### DIFF
--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -194,7 +194,7 @@ def create_aws_clients(region, profile, *clients):
 
     # add the created clients to the cache
     client_cache[client_key] = aws_clients
-    return aws_clients
+    return dict(aws_clients)
   except ClientError as error:
     raise RuntimeError("Exception logging in with Session() and creating clients", error)
 

--- a/efopen/ef_utils.py
+++ b/efopen/ef_utils.py
@@ -174,7 +174,7 @@ def create_aws_clients(region, profile, *clients):
 
 
   if not new_clients:
-    return aws_clients
+    return dict(aws_clients)
   #boto3 retry config
   config = Config(
     retries={

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -575,9 +575,8 @@ class TestEFUtils(unittest.TestCase):
 
     new_clients = ef_utils.create_aws_clients(region, profile, *amazon_services)
 
-    test_service = amazon_services[0]
-
-    self.assertIs(clients[test_service], new_clients[test_service], "Old clients should be the same in both dicts, as they are cached")
+    for k in new_clients:
+      self.assertIs(clients[k], new_clients[k], "Old clients should be the same in both dicts, as they are cached")
     self.assertIsNot(clients, new_clients, "New client dicts should not be the same object as old client dicts, even though the clients are the same")
     self.assertNotEqual(clients, new_clients, "New clients should not be affected by the update")
 

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -544,6 +544,43 @@ class TestEFUtils(unittest.TestCase):
     for service, client in built_clients.items():
       self.assertEquals(new_clients.get(service), client)
 
+  @patch('boto3.Session')
+  def test_create_aws_clients_cache_posoning(self, mock_session_constructor):
+    """
+    Test that create_aws_clients does not allow cache poisoning by returning a
+    different dict at the same time.
+
+    Check that we get the same clients every time.
+
+    Args:
+      mock_session_constructor: MagicMock, returns Mock object representing a boto3.Session object
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    mock_session = Mock(name="mock-boto3-session")
+    # make sure we get different clients on every call
+    mock_session.client.side_effect = lambda *args, **kwargs: Mock(name="mock-boto3-session")
+    mock_session_constructor.return_value = mock_session
+    amazon_services = ["acm", "batch", "ec2", "sqs"]
+    new_amazon_services = amazon_services + ["cloudfront"]
+    region, profile = "us-west-2", "testing"
+
+    clients = ef_utils.create_aws_clients(region, profile, *amazon_services)
+
+    clients.update([('not-a-service', 'not-a-client')])
+
+    new_clients = ef_utils.create_aws_clients(region, profile, *amazon_services)
+
+    test_service = amazon_services[0]
+
+    self.assertIs(clients[test_service], new_clients[test_service], "Old clients should be the same in both dicts, as they are cached")
+    self.assertIsNot(clients, new_clients, "New client dicts should not be the same object as old client dicts, even though the clients are the same")
+    self.assertNotEqual(clients, new_clients, "New clients should not be affected by the update")
+
 
   def test_get_account_id(self):
     """

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -585,8 +585,6 @@ class TestEFUtils(unittest.TestCase):
     Test that create_aws_clients does not allow cache poisoning by returning a
     different dict at the same time.
 
-    Check that we get the same clients every time.
-
     Args:
       mock_session_constructor: MagicMock, returns Mock object representing a boto3.Session object
 

--- a/tests/unit_tests/test_ef_utils.py
+++ b/tests/unit_tests/test_ef_utils.py
@@ -545,7 +545,7 @@ class TestEFUtils(unittest.TestCase):
       self.assertEquals(new_clients.get(service), client)
 
   @patch('boto3.Session')
-  def test_create_aws_clients_cache_posoning(self, mock_session_constructor):
+  def test_create_aws_clients_cache_poisoning(self, mock_session_constructor):
     """
     Test that create_aws_clients does not allow cache poisoning by returning a
     different dict at the same time.


### PR DESCRIPTION
# Ticket
OPS-17910

# Details
Production deployments using `--percent` to scale based on current desired count started performing very slowly. @AlexBantiuc has noticed that these started deploying with a max batch size of 1 and were reporting a missing current desired count.

```
+ ef-cf ./cloudformation/services/templates/service.json prod --commit --poll --percent 10
Modifying deploy rate to 10%
Service prod-service [current desired: missing, calculated max batch size: 1] 
```

## Issue
https://github.com/crunchyroll/ef-open/pull/59 has added a performance improvement in the way of caching the AWS clients instead of recreating them each time a part of ef-open needs them. This worked fine, for a while.

https://github.com/crunchyroll/ef-open/pull/233 uncovered a flaw in the implementation of the caching, where the returned dict was the exact same dict that was part of the cache. An [update](https://github.com/crunchyroll/ef-open/pull/233/files#diff-b4d9e8dd86e715286f91c3091472abd2e66c89d182a988fb43e9720ae40178e7R257) on the returned dict results in updating/poisoning the current cache. 
In this specific instance, the update replaces the `us-west-2` region session with the `us-west-1` session - subsequent calls for _new_ clients via `create_aws_clients` with `us-west-2` would generate clients with the `us-west-1` region. Fortunately, the only affected client was `autoscaling`.

### Code reproduction
Run in an ef-open enabled repository
```python

from efopen import ef_utils
clients = ef_utils.create_aws_clients('us-west-2', None, 'cloudformation')
print(clients)
# {'SESSION': Session(region_name='us-west-2'), 'cloudformation': <botocore.client.CloudFormation object at 0x1108dc410>}

clients_west1 = ef_utils.create_aws_clients('us-west-1', None, 'wafv2')
clients.update(clients_west1)
print(clients)
# {'SESSION': Session(region_name='us-west-1'), 'cloudformation': <botocore.client.CloudFormation object at 0x109b1d490>, 'wafv2': <botocore.client.WAFV2 object at 0x10a61c390>}

new_west2_clients = ef_utils.create_aws_clients('us-west-2', None, 'sts')
print(new_west2_clients)
# {'SESSION': Session(region_name='us-west-1'), 'sts': <botocore.client.STS object at 0x109d50190>, 'cloudformation': <botocore.client.CloudFormation object at 0x109b1d490>, 'wafv2': <botocore.client.WAFV2 object at 0x10a61c390>}
print(clients)
# {'SESSION': Session(region_name='us-west-1'), 'sts': <botocore.client.STS object at 0x109d50190>, 'cloudformation': <botocore.client.CloudFormation object at 0x109b1d490>, 'wafv2': <botocore.client.WAFV2 object at 0x10a61c390>}
```