### PR TITLE
OPSOC-2054 update cfn-lint version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'boto3>=1.17.112',
         'click<=7.1.2',
         'PyYAML<=5.4.1',
-        'cfn-lint',
+        'cfn-lint>=0.68.1',
         'netaddr==0.8.0',
         'requests<=2.25.1',
         'tenacity==7.0.0',


### PR DESCRIPTION
# Ticket
OPSOC-2054

# Details
Updates version constraint on the cfn-lint dependency, which is used for the `ef-cf --lint` command. OPSOC was created due to the linter being out of date and causing false positives on error checking. 
