### PR TITLE
Add support to Stack level tags in service_registry [DO NOT MERGE]

### DIFF
--- a/efopen/ef_cf.py
+++ b/efopen/ef_cf.py
@@ -151,6 +151,24 @@ def resolve_template(template, profile, env, region, service, skip_symbols, verb
   else:
     return resolver.template
 
+def resolve_tags(tags, profile, env, region, service, skip_symbols, verbose):
+  # resolve {{SYMBOLS}} in the passed tags array
+  resolver = EFTemplateResolver(profile=profile, target_other=True, env=env,
+                                region=region, service=service, skip_symbols=skip_symbols, verbose=verbose)
+  for tag in tags:
+    key = tag.get("Key")
+    value = tag.get("Value")
+    if key is None or value is None:
+      fail("Tags for service {} are malformed. Tags should follow the following structure:"
+           "[{{'Key': 'string', 'Value': 'string'}}],".format(service))
+    resolver.load(str(key))
+    new_key = resolver.render()
+    resolver.load(str(value))
+    new_value = resolver.render()
+    tag["Key"] = new_key
+    tag["Value"] = new_value
+  return tags
+
 
 def is_stack_termination_protected_env(env):
   return env in EFConfig.STACK_TERMINATION_PROTECTED_ENVS
@@ -359,6 +377,19 @@ def main():
 
   print("Template passed validation")
 
+  # Get tags from service_registry.
+  service_tags = context.service_registry.service_record(service_name).get("tags", [])
+  if len(service_tags) > 0:
+    service_tags = resolve_tags(
+      tags=service_tags,
+      profile=profile,
+      env=context.env,
+      region=region,
+      service=service_name,
+      skip_symbols=context.skip_symbols,
+      verbose=context.verbose
+    )
+
   # DO IT
   try:
     if context.changeset:
@@ -369,7 +400,8 @@ def main():
         Parameters=parameters,
         Capabilities=['CAPABILITY_AUTO_EXPAND', 'CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
         ChangeSetName=stack_name,
-        ClientToken=stack_name
+        ClientToken=stack_name,
+        Tags=service_tags
       )
       if is_stack_termination_protected_env(context.env):
         enable_stack_termination_protection(clients, stack_name)
@@ -383,7 +415,8 @@ def main():
           StackName=stack_name,
           TemplateBody=template,
           Parameters=parameters,
-          Capabilities=['CAPABILITY_AUTO_EXPAND', 'CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM']
+          Capabilities=['CAPABILITY_AUTO_EXPAND', 'CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+          Tags=service_tags
         )
         if is_stack_termination_protected_env(context.env):
           enable_stack_termination_protection(clients, stack_name)


### PR DESCRIPTION
# Ticket
[OPS-19368](https://jira.tenkasu.net/browse/OPS-19368)

# Details
> This change enables the possibility to add tags in the service registry. This tags will apply as stack-level tags [stack-level tags](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).

> Both Key and Value support templating, so you can add a tag like this:
```
{"Key": "env", "Value": "{{ENV}}"}
```
[Check this to see an example.
](https://github.com/crunchyroll/ellation_formation/blob/afabc67e37ca37a592fcf0d1843021be0615ea30/service_registry.json#L3746)
