### PR TITLE
OPS-19724 add lambda version lookups 

### DIFF
--- a/efopen/ef_template_resolver.py
+++ b/efopen/ef_template_resolver.py
@@ -250,17 +250,18 @@ class EFTemplateResolver(object):
     ]
     # Create clients in the us-east-1 region. This is required for certain APIs.
     us_east_1_clients = [
+      "lambda",
       "wafv2"
     ]
 
     try:
       EFTemplateResolver.__CLIENTS = create_aws_clients(self.resolved["REGION"], profile, *clients)
-      EFTemplateResolver.__CLIENTS.update(create_aws_clients("us-east-1", profile, *us_east_1_clients))
+      EFTemplateResolver.__US_EAST_1_CLIENTS = create_aws_clients("us-east-1", profile, *us_east_1_clients)
     except RuntimeError as error:
       fail("Exception logging in with Session()", error)
 
     # Create EFAwsResolver object for interactive lookups
-    EFTemplateResolver.__AWSR = EFAwsResolver(EFTemplateResolver.__CLIENTS)
+    EFTemplateResolver.__AWSR = EFAwsResolver(EFTemplateResolver.__CLIENTS, EFTemplateResolver.__US_EAST_1_CLIENTS)
     # Create EFConfigResolver object for ef tooling config lookups
     EFTemplateResolver.__EFCR = EFConfigResolver()
     # Create EFVersionResolver object for version lookups


### PR DESCRIPTION
# Ticket
OPS-19724

# Details
Allows ef-open to retrieve the latest version number of a lambda / lambda@edge via dynamic lookup. Moved us-east-1 boto clients to a separate client map as we potentially need access to both lambda clients simultaniously. As a result, I needed to also updated all wafv2 lookups to use this new us-east-1 client object. 
