### PR TITLE
Update subnets resolver to search only public subnets

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: gitleaks-action
+    - id: gitleaks-action
+      name: gitleaks-action
       uses: crunchyroll/gitleaks-action@master

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
+      uses: crunchyroll/gitleaks-action@master

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,6 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - id: gitleaks-action
-      name: gitleaks-action
-      uses: crunchyroll/gitleaks-action@master
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@master

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -808,11 +808,7 @@ class TestEFAwsResolver(unittest.TestCase):
     }
     route_tables_response = {
       "RouteTables": [
-        {
-          "Routes":   {
-            "GatewayId": "igw-fdaa769a"
-          }
-        }
+        {"Routes":   [{"GatewayId": "igw-fdaa769a"}]}
       ]
     }
     self._clients["ec2"].describe_subnets.return_value = subnets_response

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -806,7 +806,17 @@ class TestEFAwsResolver(unittest.TestCase):
         }
       ]
     }
+    route_tables_response = {
+      "RouteTables": [
+        {
+          "Routes":   {
+            "GatewayId": "igw-fdaa769a"
+          }
+        }
+      ]
+    }
     self._clients["ec2"].describe_subnets.return_value = subnets_response
+    self._clients["ec2"].describe_route_tables.return_value = route_tables_response
     ef_aws_resolver = EFAwsResolver(self._clients)
     result = ef_aws_resolver.lookup("ec2:vpc/subnets,target_subnet_name")
     self.assertEquals(target_subnet_id, result)

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -820,7 +820,7 @@ class TestEFAwsResolver(unittest.TestCase):
   @patch('ef_aws_resolver.EFAwsResolver.ec2_vpc_vpc_id')
   def test_ec2_vpc_subnets_not_public(self, mock_ec2_vpc_vpc_id):
     """
-    Tests ec2_vpc_subnets to see if it returns None where there are no public subnets
+    Tests ec2_vpc_subnets to see if it returns None when there are no public subnets
 
     Args:
       mock_ec2_vpc_vpc_id: MagicMock, returns mock vpc id

--- a/tests/unit_tests/test_ef_aws_resolver.py
+++ b/tests/unit_tests/test_ef_aws_resolver.py
@@ -818,6 +818,44 @@ class TestEFAwsResolver(unittest.TestCase):
     self.assertEquals(target_subnet_id, result)
 
   @patch('ef_aws_resolver.EFAwsResolver.ec2_vpc_vpc_id')
+  def test_ec2_vpc_subnets_not_public(self, mock_ec2_vpc_vpc_id):
+    """
+    Tests ec2_vpc_subnets to see if it returns None where there are no public subnets
+
+    Args:
+      mock_ec2_vpc_vpc_id: MagicMock, returns mock vpc id
+
+    Returns:
+      None
+
+    Raises:
+      AssertionError if any of the assert checks fail
+    """
+    mock_ec2_vpc_vpc_id.return_value = 'mock_vpc_id'
+    subnets_response = {
+      "Subnets": [
+        {
+          "SubnetId": "subnet-9c2ea7ea"
+        }
+      ]
+    }
+    route_tables_response = {
+      "RouteTables": [
+        {
+          "Routes":   [
+            {"NatGatewayId": "nat-07e6c104f449ed846", "DestinationCidrBlock": "0.0.0.0/0"},
+            {"GatewayId": "local", "DestinationCidrBlock": "10.213.64.0/18"}
+          ]
+        }
+      ]
+    }
+    self._clients["ec2"].describe_subnets.return_value = subnets_response
+    self._clients["ec2"].describe_route_tables.return_value = route_tables_response
+    ef_aws_resolver = EFAwsResolver(self._clients)
+    result = ef_aws_resolver.lookup("ec2:vpc/subnets,target_subnet_name")
+    self.assertIsNone(result)
+
+  @patch('ef_aws_resolver.EFAwsResolver.ec2_vpc_vpc_id')
   def test_ec2_vpc_subnets_no_match(self, mock_ec2_vpc_vpc_id):
     """
     Tests ec2_vpc_subnets to see if returns None when there are no matches


### PR DESCRIPTION
## Jira Ticket
[PLAT-500](https://jira.tenkasu.net/browse/PLAT-500)

Checkout also pr #11584

## Description

Update ef_cf to only search for public subnets. The reason for this change is that we are planning to create new private subnets. Right now only public subnets exists, and when we create the new subnets things will be deployed in the new subnets and break. The solution for this is to modify ef_open to only retrieve public subnets. 

## Can this PR be merged / deployed at any time?
- [x] Yes
- [ ] No, only at specific time (please specify below)
- [ ] No, only after certain conditions are met (please specify below)

## How was this tested?
i tested in proto0. 